### PR TITLE
Attempt to fix CI build error

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     id("nebula.maven-apache-license") version "18.4.0"
     id("com.gradle.plugin-publish") version "1.1.0"
     id("com.github.hierynomus.license") version "0.16.1"
+    // id("com.github.jk1.license-report") version "latest.release"
 }
 
 group = "org.openrewrite"
@@ -129,7 +130,7 @@ java {
 }
 
 tasks.named<JavaCompile>("compileJava") {
-    options.release.set(8)
+    options.release.set(11)
 }
 
 val rewriteVersion = "7.40.6"
@@ -155,6 +156,7 @@ dependencies {
     implementation("org.apache.ivy:ivy:2.5.1")
     implementation("gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:latest.release")
     implementation("com.github.jk1:gradle-license-report:latest.release")
+
     implementation("org.owasp:dependency-check-gradle:latest.release")
     implementation("com.netflix.nebula:gradle-contacts-plugin:latest.release")
     implementation("com.netflix.nebula:gradle-info-plugin:latest.release")

--- a/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
@@ -96,7 +96,7 @@ public class RewriteJavaPlugin implements Plugin<Project> {
     }
 
     private static void configureJavaCompile(Project project) {
-        project.getTasks().named("compileJava", JavaCompile.class, task -> task.getOptions().getRelease().set(8));
+        project.getTasks().named("compileJava", JavaCompile.class, task -> task.getOptions().getRelease().set(11));
 
         project.getTasks().withType(JavaCompile.class).configureEach(task -> {
             task.getOptions().setEncoding("UTF-8");


### PR DESCRIPTION
We are seeing this error in the build, this PR attempts to solve this error.
```
* What went wrong:
Execution failed for task ':compileJava'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not resolve com.github.jk1:gradle-license-report:latest.release.
     Required by:
         project :
      > No matching variant of com.github.jk1:gradle-license-report:2.2 was found. The consumer was configured to find an API of a library compatible with Java 8, preferably in the form of class files, preferably optimized for standard JVMs, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '7.6' but:
          - Variant 'apiElements' capability com.github.jk1:gradle-license-report:2.2 declares an API of a library, packaged as a jar, and its dependencies declared externally:
```
