### PR TITLE
fix: Suppress additional CVEs in bcprov-jdk18on transitive dependency

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -141,6 +141,10 @@
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.bouncycastle/bcprov\-jdk18on@.*$</packageUrl>
         <cve>CVE-2024-34447</cve>
+        <cve>CVE-2024-30172</cve>
+        <cve>CVE-2024-30171</cve>
         <cve>CVE-2024-29857</cve>
+        <cve>CVE-2023-33202</cve>
+        <cve>CVE-2023-33201</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
## What's changed?
Suppress additional CVEs found in transitive bcprov-jdk18on dependency.

## What's your motivation?
Pass vulnerability scan.

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
@natedanner 

## Have you considered any alternatives or workarounds?
No.

## Any additional context

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
