### PR TITLE
chore: add shared suppression definition

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -260,4 +260,5 @@ configure<LicenseExtension> {
     strictCheck = true
     exclude("**/versions.properties")
     exclude("**/*.txt")
+    exclude("**/suppressions.xml")
 }

--- a/src/main/java/org/openrewrite/gradle/RewriteDependencyCheckPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteDependencyCheckPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,12 @@ import org.gradle.api.Project;
 import org.owasp.dependencycheck.gradle.DependencyCheckPlugin;
 import org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension;
 
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+
 public class RewriteDependencyCheckPlugin implements Plugin<Project> {
 
     @Override
@@ -28,22 +34,55 @@ public class RewriteDependencyCheckPlugin implements Plugin<Project> {
 
         float failBuildOnCVSS = Float
                 .parseFloat(System.getenv("FAIL_BUILD_ON_CVSS") != null ? System.getenv("FAIL_BUILD_ON_CVSS") : "9");
+        String format = System.getenv("OWASP_REPORT_FORMAT") != null ? System.getenv("OWASP_REPORT_FORMAT") : "HTML";
 
-        // check to see if `suppressions.xml` exists in project root
-        if (project.file("suppressions.xml").exists()) {
-            project.getExtensions().configure(DependencyCheckExtension.class, ext -> {
-                ext.setSuppressionFile(project.file("suppressions.xml").getPath());
-            });
-        }
+        // upsert suppressions file
+        generateSuppressionsFile(project);
 
         project.getExtensions().configure(DependencyCheckExtension.class, ext -> {
             ext.getAnalyzers().setAssemblyEnabled(false);
             ext.getAnalyzers().setNodeAuditEnabled(false);
             ext.getAnalyzers().setNodeEnabled(false);
             ext.setFailBuildOnCVSS(failBuildOnCVSS);
+            ext.setFormat(format);
             ext.getNvd().setApiKey(System.getenv("NVD_API_KEY"));
 
         });
 
+    }
+
+    private void generateSuppressionsFile(Project project) {
+        // Ensure the build directory exists
+        File buildDir = project.getLayout().getBuildDirectory().get().getAsFile();
+        if (!buildDir.exists()) {
+            project.getLogger().info("Creating build directory: {}", buildDir.getAbsolutePath());
+            buildDir.mkdirs();
+        }
+        // Copy suppressions.xml from the current loaded class's resources directory to the project's build directory
+        File sharedSuppressionsFile = new File(buildDir, "suppressions.xml");
+        File projectSuppressionsFile = new File(project.getProjectDir(), "suppressions.xml");
+
+        // Upsert shared suppression file
+        try (InputStream inputStream = getClass().getResourceAsStream("/suppressions.xml")) {
+            if (inputStream != null) {
+                Files.copy(inputStream, sharedSuppressionsFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            } else {
+                throw new FileNotFoundException("Resource suppressions.xml not found");
+            }
+        } catch (IOException e) {
+            project.getLogger().error("Failed to copy suppressions.xml", e);
+            throw new UncheckedIOException("Failed to copy suppressions.xml", e);
+        }
+
+        project.getExtensions().configure(DependencyCheckExtension.class, ext -> {
+            List<String> suppressionFiles = new ArrayList<>();
+            suppressionFiles.add(sharedSuppressionsFile.getAbsolutePath());
+            project.getLogger().info("Adding shared suppressions file: {}", sharedSuppressionsFile.getAbsolutePath());
+            if (projectSuppressionsFile.exists()) {
+                project.getLogger().info("Adding project suppressions file: {}", projectSuppressionsFile.getAbsolutePath());
+                suppressionFiles.add(projectSuppressionsFile.getAbsolutePath());
+            }
+            ext.setSuppressionFiles(suppressionFiles);
+        });
     }
 }

--- a/src/main/resources/suppressions.xml
+++ b/src/main/resources/suppressions.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress until="2024-08-25Z">
+        <notes><![CDATA[
+   file name: rewrite-gradle-8.9.0-SNAPSHOT.jar: gradle-testing-base-6.1.1.jar, gradle-testing-jvm-6.1.1.jar, gradle-resources-6.1.1.jar, gradle-messaging-6.1.1.jar, gradle-logging-6.1.1.jar, gradle-native-6.1.1.jar, gradle-core-api-6.1.1.jar
+        sev: HIGH
+        reason: This is a false positive. The vulnerability is in the Gradle 7.6.2 and 8.2 and these are gradle core api's
+]]></notes>
+        <filePath regex="true">
+            .*META-INF\/rewrite\/classpath\/gradle.*6\.1\.1\.jar
+        </filePath>
+        <cve>CVE-2023-35947</cve>
+        <cve>CVE-2021-29428</cve>
+        <cve>CVE-2020-11979</cve>
+        <cve>CVE-2021-32751</cve>
+        <cve>CVE-2021-29427</cve>
+    </suppress>
+    <suppress until="2024-09-25Z">
+        <notes><![CDATA[
+        file name: rewrite-gradle-8.9.0-SNAPSHOT.jar: gradle-enterprise-gradle-plugin-3.13.4.jar
+        sev: HIGH
+        reason: This is a false positive. The vulnerability is in the Gradle 7.6.2 and 8.2 and this is a plugin jar
+   ]]></notes>
+        <cve>CVE-2019-11065</cve>
+        <cve>CVE-2019-11402</cve>
+        <cve>CVE-2019-11403</cve>
+        <cve>CVE-2019-15052</cve>
+        <cve>CVE-2019-16370</cve>
+        <cve>CVE-2020-11979</cve>
+        <cve>CVE-2020-15767</cve>
+        <cve>CVE-2020-15773</cve>
+        <cve>CVE-2021-29428</cve>
+        <cve>CVE-2021-29429</cve>
+        <cve>CVE-2021-32751</cve>
+        <cve>CVE-2021-41589</cve>
+        <cve>CVE-2022-25364</cve>
+        <cve>CVE-2022-30587</cve>
+        <cve>CVE-2023-35946</cve>
+        <cve>CVE-2023-35947</cve>
+        <cve>CVE-2023-42445</cve>
+        <cve>CVE-2023-44387</cve>
+        <cve>CVE-2023-49238</cve>
+    </suppress>
+    <suppress until="2024-09-25Z">
+        <notes><![CDATA[
+       file name: rewrite-gradle-8.34.0-SNAPSHOT.jar: develocity-gradle-plugin-3.17.6.jar: junit-platform-engine-1.10.3.jar
+       ]]></notes>
+        <cve>CVE-2023-45161</cve>
+        <cve>CVE-2023-45163</cve>
+        <cve>CVE-2023-5964</cve>
+        <cve>CVE-2019-15052</cve>
+        <cve>CVE-2023-35947</cve>
+        <cve>CVE-2021-29428</cve>
+        <cve>CVE-2020-11979</cve>
+        <cve>CVE-2021-32751</cve>
+        <cve>CVE-2023-44387</cve>
+        <cve>CVE-2019-11065</cve>
+        <cve>CVE-2019-16370</cve>
+        <cve>CVE-2021-29429</cve>
+        <cve>CVE-2023-35946</cve>
+        <cve>CVE-2023-42445</cve>
+    </suppress>
+    <suppress until="2024-09-25Z">
+        <notes><![CDATA[
+       file name: rewrite-jenkins-0.11.0-SNAPSHOT.jar
+       sev: HIGH
+       reason: False positive.
+       ]]></notes>
+        <cve>CVE-2018-1000600</cve>
+        <cve>CVE-2018-1000183</cve>
+        <cve>CVE-2018-1000184</cve>
+        <cve>CVE-2023-46650</cve>
+        <cve>CVE-2022-36885</cve>
+    </suppress>
+    <suppress until="2024-09-25Z">
+        <notes><![CDATA[
+       file name: rewrite-openapi-0.6.0-SNAPSHOT.jar
+           sev: HIGH
+           reason: False positive.
+       ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.openrewrite\.recipe/rewrite-openapi@.*$</packageUrl>
+        <cve>CVE-2022-24863</cve>
+    </suppress>
+    <suppress until="2024-09-25Z">
+        <notes><![CDATA[
+       file name: spring-*.jar
+       sev: CRITICAL
+       reason: Evidence is from jars packaged into `rewrite-spring` as reference and not executed code.
+       ]]></notes>
+        <cve>CVE-2018-1258</cve>
+        <cve>CVE-2016-1000027</cve>
+        <cve>CVE-2023-34053</cve>
+        <cve>CVE-2023-20873</cve>
+        <cve>CVE-2022-27772</cve>
+        <cve>CVE-2023-20883</cve>
+        <cve>CVE-2022-22965</cve>
+        <cve>CVE-2022-22950</cve>
+        <cve>CVE-2023-20861</cve>
+        <cve>CVE-2022-22968</cve>
+        <cve>CVE-2022-22970</cve>
+        <cve>CVE-2024-22259</cve>
+        <cve>CVE-2024-22262</cve>
+    </suppress>
+    <suppress until="2024-09-25Z">
+            <notes><![CDATA[
+       file name: guava-31.1-jre.jar
+       sev: HIGH
+         reason: False positive. Not referenced
+       ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
+        <cve>CVE-2023-2976</cve>
+        <cve>CVE-2020-8908</cve>
+    </suppress>
+    <suppress until="2024-09-25Z">
+        <notes><![CDATA[
+            file name: snakeyaml-1.33.jar
+            Severity: HIGH
+            False positive: We are not parsing untrusted user input. Not used directly in this repository.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+        <cve>CVE-2022-1471</cve>
+    </suppress>
+    <suppress until="2024-09-25Z">
+        <notes><![CDATA[
+   file name: org.eclipse.jgit-4.4.1.201607150455-r.jar
+       sev: High
+         reason: dependencies of refaster.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jgit/org\.eclipse\.jgit@.*$</packageUrl>
+        <vulnerabilityName>CVE-2023-4759</vulnerabilityName>
+    </suppress>
+    <suppress until="2024-09-25Z">
+        <notes><![CDATA[
+   file name: protobuf-java-3.19.2.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.protobuf/protobuf-java@.*$</packageUrl>
+        <cve>CVE-2022-3171</cve>
+        <cve>CVE-2022-3509</cve>
+        <cve>CVE-2022-3510</cve>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
upserted into rewrite project when task is run. configures owasp dependency-check to also scan for
repo-level suppression files and include as well

re: https://github.com/moderneinc/dependency-vulnerability-reports/issues/709
