### PR TITLE
chore: disable retirejs scanning

### DIFF
--- a/src/main/java/org/openrewrite/gradle/RewriteDependencyCheckPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteDependencyCheckPlugin.java
@@ -43,6 +43,9 @@ public class RewriteDependencyCheckPlugin implements Plugin<Project> {
             ext.getAnalyzers().setAssemblyEnabled(false);
             ext.getAnalyzers().setNodeAuditEnabled(false);
             ext.getAnalyzers().setNodeEnabled(false);
+            ext.getAnalyzers().retirejs(
+                    retireJs -> retireJs.setEnabled(false)
+            );
             ext.setFailBuildOnCVSS(failBuildOnCVSS);
             ext.setFormat(format);
             ext.getNvd().setApiKey(System.getenv("NVD_API_KEY"));


### PR DESCRIPTION
not applicable for openrewrite repositories

re https://github.com/moderneinc/dependency-vulnerability-reports/issues/753
