### PR TITLE
Adding RewriteDependencyCheckPlugin to the base plugin

### DIFF
--- a/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
@@ -36,6 +36,8 @@ public class RewriteJavaPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        project.getPlugins().apply(RewriteDependencyCheckPlugin.class);
+
         RewriteJavaExtension ext = project.getExtensions().create("rewriteJava", RewriteJavaExtension.class);
         ext.getJacksonVersion().convention("2.17.2");
 
@@ -105,7 +107,7 @@ public class RewriteJavaPlugin implements Plugin<Project> {
 //        );
 
         project.getTasks().withType(Test.class).configureEach(task -> {
-            if(System.getenv("CI") == null) {
+            if (System.getenv("CI") == null) {
                 // Developer machines typically use CPUs with hyper-threading, so the logical core count is double
                 // what is useful to enable
                 task.setMaxParallelForks(


### PR DESCRIPTION
Some repositories are failing to complete the vulnerability check because they are missing the "DependencyCheck", which is provided by the DependencyCheckPlugin. We want to validate vulnerabilities on all repositories, but not all repositories have the "RewriteDependencyCheckPlugin" which applies the "DependencyCheckPlugin". Instead of adding it to all repositories, I'm adding this to the base plugin.

Note we are applying the RewriteDependencyCheckPlugin instead of the DependencyCheckPlugin to the base plugin. This is done because the RewriteDependencyCheckPlugin will apply the shared suppressions to all repositories when we run the validation.

