### PR TITLE
Removing duplicate application of RewriteDependencyCheck plugin

### DIFF
--- a/src/main/java/org/openrewrite/gradle/RewriteRecipeLibraryPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteRecipeLibraryPlugin.java
@@ -36,7 +36,6 @@ public class RewriteRecipeLibraryPlugin implements Plugin<Project> {
         project.getPlugins().apply(RewriteJavaPlugin.class);
         project.getPlugins().apply(RewriteLicensePlugin.class);
         project.getPlugins().apply(RewriteMetadataPlugin.class);
-        project.getPlugins().apply(RewriteDependencyCheckPlugin.class);
         project.getPlugins().apply(RewriteBuildInputLoggingPlugin.class);
         project.getPlugins().apply(RewritePublishPlugin.class);
         project.getPlugins().apply(PublishVerificationPlugin.class);


### PR DESCRIPTION
The RewriteJava plugin applies the RewriteDependencyCheck plugin; we don't need to do this twice, this change was done in this [commit](https://github.com/openrewrite/rewrite-build-gradle-plugin/commit/6f1ef1175a8e5f0b43cdca0d28192a7cbc9a5d45) 

