### PR TITLE
Allow proprietary license on BOM

### DIFF
--- a/src/main/java/org/openrewrite/gradle/ModerneProprietaryLicensePlugin.java
+++ b/src/main/java/org/openrewrite/gradle/ModerneProprietaryLicensePlugin.java
@@ -18,42 +18,51 @@ package org.openrewrite.gradle;
 import nebula.plugin.publishing.maven.MavenBasePublishPlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.maven.internal.publication.DefaultMavenPom;
 import org.gradle.jvm.tasks.Jar;
+import org.openrewrite.internal.lang.Nullable;
 
 public class ModerneProprietaryLicensePlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
         // Empty JARs are OK: https://central.sonatype.org/publish/requirements/#supply-javadoc-and-sources
-        project.getTasks().named("sourcesJar", Jar.class).get().setEnabled(false);
+        Jar emptySourcesJar;
+        Task sourcesJar = project.getTasks().findByName("sourcesJar");
+        if (sourcesJar != null) {
+            sourcesJar.setEnabled(false);
 
-        Jar sourceJar = project.getTasks().create("emptySourceJar", Jar.class, task -> {
-            task.from("README.md");
-            task.getArchiveClassifier().set("sources");
-        });
-
-        project.getTasks().named("assemble", task -> task.dependsOn(sourceJar));
+            emptySourcesJar = project.getTasks().create("emptySourceJar", Jar.class, task -> {
+                task.from("README.md");
+                task.getArchiveClassifier().set("sources");
+            });
+            project.getTasks().named("assemble", task -> task.dependsOn(emptySourcesJar));
+        } else {
+            emptySourcesJar = null;
+        }
 
         project.getPlugins().apply(MavenBasePublishPlugin.class);
         PublishingExtension publishing = project.getExtensions().getByType(PublishingExtension.class);
-        publishing.publications(publications -> publications.withType(MavenPublication.class,
-                p -> configureLicense(p, sourceJar)));
+        publishing.publications(publications ->
+                publications.withType(MavenPublication.class, p -> configureLicense(p, emptySourcesJar)));
     }
 
-    private void configureLicense(MavenPublication publication, Jar sourceJar) {
-        publication.artifact(sourceJar);
+    private void configureLicense(MavenPublication publication, @Nullable Jar sourcesJar) {
+        if (sourcesJar != null) {
+            publication.artifact(sourcesJar);
+        }
 
-        publication.pom(pom -> {
-            pom.licenses(licenses -> {
-                licenses.license(license -> {
-                    ((DefaultMavenPom) licenses).getLicenses().clear();
-                    license.getName().set("Moderne Proprietary License");
-                    license.getUrl().set("https://docs.moderne.io/licensing/overview");
-                });
-            });
-        });
+        publication.pom(pom ->
+                pom.licenses(licenses ->
+                        licenses.license(license -> {
+                            ((DefaultMavenPom) licenses).getLicenses().clear();
+                            license.getName().set("Moderne Proprietary License");
+                            license.getUrl().set("https://docs.moderne.io/licensing/overview");
+                        })
+                )
+        );
     }
 }


### PR DESCRIPTION
## What's changed?
Tolerate absence of `sourcesJar`, and if missing do not add empty sourcesJar artifact.

## What's your motivation?
`moderne-recipe-bom` failed to run the plugin, as that's only a generated `pom.xml` file.