### PR TITLE
Add task to create type tables to replace resource jars

### DIFF
--- a/src/main/java/org/openrewrite/gradle/RecipeDependenciesDownloadTask.java
+++ b/src/main/java/org/openrewrite/gradle/RecipeDependenciesDownloadTask.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
+@Deprecated
 public class RecipeDependenciesDownloadTask extends DefaultTask {
 
     private static final ChainVersionMatcher versionMatcher = new ChainVersionMatcher();

--- a/src/main/java/org/openrewrite/gradle/RecipeDependenciesTypeTableTask.java
+++ b/src/main/java/org/openrewrite/gradle/RecipeDependenciesTypeTableTask.java
@@ -15,8 +15,6 @@
  */
 package org.openrewrite.gradle;
 
-import org.apache.ivy.plugins.latest.LatestLexicographicStrategy;
-import org.apache.ivy.plugins.version.*;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.SourceDirectorySet;
@@ -32,16 +30,6 @@ import java.util.Map;
 import static java.util.Objects.requireNonNull;
 
 public class RecipeDependenciesTypeTableTask extends DefaultTask {
-
-    private static final ChainVersionMatcher versionMatcher = new ChainVersionMatcher();
-
-    static {
-        versionMatcher.add(new ExactVersionMatcher());
-        versionMatcher.add(new LatestVersionMatcher());
-        versionMatcher.add(new PatternVersionMatcher());
-        versionMatcher.add(new SubVersionMatcher());
-        versionMatcher.add(new VersionRangeMatcher("latest", new LatestLexicographicStrategy()));
-    }
 
     @TaskAction
     void download() throws IOException {

--- a/src/main/java/org/openrewrite/gradle/RecipeDependenciesTypeTableTask.java
+++ b/src/main/java/org/openrewrite/gradle/RecipeDependenciesTypeTableTask.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle;
+
+import org.apache.ivy.plugins.latest.LatestLexicographicStrategy;
+import org.apache.ivy.plugins.version.*;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.tasks.TaskAction;
+import org.openrewrite.java.internal.parser.TypeTable;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class RecipeDependenciesTypeTableTask extends DefaultTask {
+
+    private static final ChainVersionMatcher versionMatcher = new ChainVersionMatcher();
+
+    static {
+        versionMatcher.add(new ExactVersionMatcher());
+        versionMatcher.add(new LatestVersionMatcher());
+        versionMatcher.add(new PatternVersionMatcher());
+        versionMatcher.add(new SubVersionMatcher());
+        versionMatcher.add(new VersionRangeMatcher("latest", new LatestLexicographicStrategy()));
+    }
+
+    @TaskAction
+    void download() throws IOException {
+        SourceDirectorySet resources = getProject().getExtensions().getByType(JavaPluginExtension.class)
+                .getSourceSets()
+                .getByName("main")
+                .getResources();
+
+        for (File sourceDirectory : resources.getSourceDirectories()) {
+            File tsvFile = new File(sourceDirectory, TypeTable.DEFAULT_RESOURCE_PATH);
+            File parentFile = tsvFile.getParentFile();
+            if (!parentFile.exists() && !parentFile.mkdirs()) {
+                throw new IllegalStateException("Unable to create " + parentFile);
+            }
+
+            RecipeDependenciesExtension extension = getProject().getExtensions().getByType(RecipeDependenciesExtension.class);
+            try (TypeTable.Writer writer = TypeTable.newWriter(Files.newOutputStream(tsvFile.toPath()))) {
+                for (Map.Entry<Dependency, File> dependency : extension.getResolved().entrySet()) {
+                    String group = requireNonNull(dependency.getKey().getGroup(), "group");
+                    String artifact = dependency.getKey().getName();
+                    String version = requireNonNull(dependency.getKey().getVersion(), "version");
+                    writer.jar(group, artifact, version).write(dependency.getValue().toPath());
+                    getLogger().info("Wrote %s:%s:%s to %s", group, artifact, version, tsvFile);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/openrewrite/gradle/RewriteRecipeLibraryBasePlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteRecipeLibraryBasePlugin.java
@@ -31,6 +31,7 @@ public class RewriteRecipeLibraryBasePlugin implements Plugin<Project> {
 //        project.getPlugins().apply(RewriteRecipeExamplesPlugin.class);
 
         project.getExtensions().create("recipeDependencies", RecipeDependenciesExtension.class);
+        project.getTasks().register("createTypeTable", RecipeDependenciesTypeTableTask.class);
         project.getTasks().register("downloadRecipeDependencies", RecipeDependenciesDownloadTask.class);
     }
 }

--- a/src/test/java/org/openrewrite/gradle/RecipeDependenciesTypeTableTaskTest.java
+++ b/src/test/java/org/openrewrite/gradle/RecipeDependenciesTypeTableTaskTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.java.internal.parser.TypeTable;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RecipeDependenciesTypeTableTaskTest {
+    @TempDir
+    File projectDir;
+
+    private File settingsFile;
+    private File buildFile;
+
+    @BeforeEach
+    public void setup() {
+        settingsFile = new File(projectDir, "settings.gradle");
+        buildFile = new File(projectDir, "build.gradle");
+    }
+
+    @Test
+    void createTypeTable() throws IOException {
+        Files.writeString(settingsFile.toPath(), "rootProject.name = 'my-project'");
+        File cp = new File(projectDir, TypeTable.DEFAULT_RESOURCE_PATH);
+        assertThat(cp.mkdirs()).isTrue();
+
+        //language=groovy
+        Files.writeString(buildFile.toPath(),
+                """
+                        plugins {
+                            id 'org.openrewrite.build.recipe-library-base'
+                        }
+                        repositories {
+                            mavenCentral()
+                        }
+                        recipeDependencies {
+                            parserClasspath 'com.google.guava:guava:30.1-jre'
+                            parserClasspath 'com.google.guava:guava:31.1-jre'
+                        }
+                        """);
+
+        BuildResult result = GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withArguments("createTypeTable", "--stacktrace")
+                .withPluginClasspath()
+                .withDebug(true)
+                .build();
+        System.out.println(result.getOutput());
+
+        assertEquals(SUCCESS, requireNonNull(result.task(":createTypeTable")).getOutcome());
+
+        assertThat(cp).isFile();
+    }
+}

--- a/src/test/java/org/openrewrite/gradle/RewriteJavaPluginTest.java
+++ b/src/test/java/org/openrewrite/gradle/RewriteJavaPluginTest.java
@@ -44,13 +44,14 @@ public class RewriteJavaPluginTest {
 
     @Test
     public void testRetry() throws IOException {
-        writeFile(settingsFile, "rootProject.name = 'my-project'");
-        String buildFileContent = """
+        Files.writeString(settingsFile.toPath(), "rootProject.name = 'my-project'");
+        Files.writeString(buildFile.toPath(),
+                //language=gradle
+                """
                 plugins {
                     id 'org.openrewrite.build.language-library'
                 }
-                """;
-        writeFile(buildFile, buildFileContent);
+                """);
 
         BuildResult result = GradleRunner.create()
                 .withProjectDir(testProjectDir)
@@ -59,9 +60,5 @@ public class RewriteJavaPluginTest {
                 .build();
 
         assertEquals(NO_SOURCE, requireNonNull(result.task(":test")).getOutcome());
-    }
-
-    private void writeFile(File destination, String content) throws IOException {
-        Files.write(destination.toPath(), content.getBytes());
     }
 }


### PR DESCRIPTION
## What's changed?
Add a new task.

## What's your motivation?
Replace resource jars.

## Anything in particular you'd like reviewers to focus on?
Should we load any existing type table to determine if it's necessary to overwrite with a new file for task avoidance?
Or can we rely on only running this task deliberately whenever a new parserClasspath entry is added?

## Have you considered any alternatives or workarounds?
We could already remove `RecipeDependenciesDownloadTask`, as that's not run automatically I believe; but then we'd immediately need to update the docs.

## Any additional context
- https://github.com/openrewrite/rewrite/pull/4932#discussion_r1924322370