### PR TITLE
TypeTable should store actual version for predictable matching

### DIFF
--- a/src/main/java/org/openrewrite/gradle/RecipeDependenciesDownloadTask.java
+++ b/src/main/java/org/openrewrite/gradle/RecipeDependenciesDownloadTask.java
@@ -32,7 +32,6 @@ import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
-@Deprecated
 public class RecipeDependenciesDownloadTask extends DefaultTask {
 
     private static final ChainVersionMatcher versionMatcher = new ChainVersionMatcher();

--- a/src/main/java/org/openrewrite/gradle/RecipeDependenciesTypeTableTask.java
+++ b/src/main/java/org/openrewrite/gradle/RecipeDependenciesTypeTableTask.java
@@ -50,7 +50,10 @@ public class RecipeDependenciesTypeTableTask extends DefaultTask {
                 for (Map.Entry<Dependency, File> dependency : extension.getResolved().entrySet()) {
                     String group = requireNonNull(dependency.getKey().getGroup(), "group");
                     String artifact = dependency.getKey().getName();
-                    String version = requireNonNull(dependency.getKey().getVersion(), "version");
+                    // Determine actual version; e.g. 5.+ might resolve to 5.3.39
+                    String version = dependency.getValue().getName()
+                            .substring(artifact.length() + 1)
+                            .replaceAll(".jar$", "");
                     writer.jar(group, artifact, version).write(dependency.getValue().toPath());
                     getLogger().info(String.format("Wrote %s:%s:%s to %s", group, artifact, version, tsvFile));
                 }


### PR DESCRIPTION
## What's changed?
Determine the actual jar version number, as opposed to the requested version number.

## What's your motivation?
We saw mismatches in
- https://github.com/openrewrite/rewrite-spring/pull/676#issuecomment-2659693986

## Anything in particular you'd like reviewers to focus on?
Called out in comments. Tagged Sam for async review.

## Have you considered any alternatives or workarounds?
We could adjust the matching as well, but then we'd be storing `../5.+/..` on disk, which could be `5.0 - 5.3`. This avoids confusion.