### PR TITLE
update owasp org.owasp.dependencycheck to latest release nd compile target to java 11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -184,7 +184,7 @@ java {
 }
 
 tasks.named<JavaCompile>("compileJava") {
-    options.release.set(8)
+    options.release.set(11)
 }
 
 val rewriteVersion = "8.45.5"
@@ -212,7 +212,7 @@ dependencies {
     implementation("org.apache.ivy:ivy:2.5.2")
     implementation("gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin:latest.release")
     implementation("com.github.jk1:gradle-license-report:1.16")
-    implementation("org.owasp:dependency-check-gradle:10.+")
+    implementation("org.owasp:dependency-check-gradle:latest.release")
     implementation("com.netflix.nebula.contacts:com.netflix.nebula.contacts.gradle.plugin:latest.release")
     implementation("com.netflix.nebula:gradle-info-plugin:latest.release")
     implementation("com.netflix.nebula.release:com.netflix.nebula.release.gradle.plugin:latest.release")


### PR DESCRIPTION
re: https://github.com/moderneinc/dependency-vulnerability-reports/issues/820

@timtebeek @sambsnyd I think this is safe as I was still table to compile rewrite-java8 in rewrite but want to make sure there isn't any other potential issues with this change.

