### PR TITLE
add task and plugin to produce recipe origin yml which contains license and url information

### DIFF
--- a/src/main/java/org/openrewrite/gradle/RewriteRecipeOriginPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteRecipeOriginPlugin.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.provider.Property;
+import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.maven.MavenPomLicense;
+import org.gradle.api.publish.maven.MavenPublication;
+import org.gradle.api.publish.maven.internal.publication.DefaultMavenPom;
+import org.gradle.api.tasks.Copy;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.language.jvm.tasks.ProcessResources;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.eclipse.jgit.util.StringUtils.capitalize;
+
+public class RewriteRecipeOriginPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        String recipeLicense = determineLicense(project);
+        String repoUrl = determineRepoUrl(project);
+
+        JavaPluginExtension java = project.getExtensions().findByType(JavaPluginExtension.class);
+        if (java == null) {
+            return;
+        }
+        SourceSet mainSource = java.getSourceSets().getByName("main");
+        TaskContainer tasks = project.getTasks();
+        TaskProvider<Copy> copyOrigins = tasks.register("copyOrigins", Copy.class);
+        //noinspection UnstableApiUsage
+        tasks.named("processResources", ProcessResources.class).configure(task -> {
+            task.dependsOn(copyOrigins);
+        });
+
+        for (File sourceDir : mainSource.getAllSource().getSrcDirs()) {
+            TaskProvider<RewriteRecipeOriginTask> attr = tasks.register(
+                    "rewriteRecipeOrigin" + capitalize(sourceDir.getName()), RewriteRecipeOriginTask.class,
+                    task -> {
+                        task.dependsOn(mainSource.getCompileJavaTaskName());
+                        task.setSources(sourceDir);
+                        task.setClasspath(mainSource.getOutput().getClassesDirs());
+                        task.setRecipeLicense(recipeLicense);
+                        task.setRepoBaseUrl(repoUrl);
+                    }
+            );
+
+            copyOrigins.configure(task -> {
+                task.dependsOn(attr);
+                task.from(attr.get().getOutputDirectory());
+                task.into(new File(project.getBuildDir(), "resources/main/META-INF/rewrite/origin"));
+            });
+        }
+    }
+
+    private String determineRepoUrl(Project project) {
+        List<String> repoUrls = project.getExtensions()
+                .getByType(PublishingExtension.class)
+                .getPublications()
+                .withType(MavenPublication.class)
+                .stream()
+                .map(MavenPublication::getPom)
+                .map(DefaultMavenPom.class::cast)
+                .map(DefaultMavenPom::getUrl)
+                .map(Property<String>::get)
+                .distinct()
+                .collect(Collectors.toList());
+
+        if (repoUrls.isEmpty()) {
+            throw new IllegalStateException("Unable to find any Repository URL");
+        }
+        if (repoUrls.size() > 1) {
+            throw new IllegalStateException("Found more than Repository URL");
+        }
+
+        return repoUrls.get(0);
+    }
+
+    private String determineLicense(Project project) {
+        List<String> licenses = project.getExtensions()
+                .getByType(PublishingExtension.class)
+                .getPublications()
+                .withType(MavenPublication.class)
+                .stream()
+                .map(MavenPublication::getPom)
+                .map(DefaultMavenPom.class::cast)
+                .map(DefaultMavenPom::getLicenses)
+                .flatMap(List::stream)
+                .map(MavenPomLicense::getUrl)
+                .map(Property<String>::get)
+                .distinct()
+                .collect(Collectors.toList());
+
+        if (licenses.isEmpty()) {
+            throw new IllegalStateException("Unable to find any License");
+        }
+        if (licenses.size() > 1) {
+            throw new IllegalStateException("Found more than one License");
+        }
+
+        return licenses.get(0);
+    }
+}

--- a/src/main/java/org/openrewrite/gradle/RewriteRecipeOriginTask.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteRecipeOriginTask.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ClassInfoList;
+import io.github.classgraph.ScanResult;
+import lombok.Getter;
+import lombok.Setter;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.tasks.*;
+import org.gradle.work.ChangeType;
+import org.gradle.work.FileChange;
+import org.gradle.work.InputChanges;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@CacheableTask
+public class RewriteRecipeOriginTask extends DefaultTask {
+
+    @Getter(onMethod_ = {
+            @SkipWhenEmpty,
+            @InputDirectory,
+            @PathSensitive(PathSensitivity.NAME_ONLY),
+            @IgnoreEmptyDirectories})
+    private final DirectoryProperty sources = getProject().getObjects().directoryProperty();
+
+    @Getter(onMethod_ = @Internal)
+    private Set<URI> classpath;
+    @Setter
+    @Getter(onMethod_ = @SkipWhenEmpty)
+    private String recipeLicense;
+    @Setter
+    @Getter(onMethod_ = @SkipWhenEmpty)
+    private String repoBaseUrl;
+
+    @OutputDirectory
+    public Path getOutputDirectory() {
+        return getProject().getBuildDir().toPath().resolve("rewrite/origin")
+                .resolve(sources.get().getAsFile().getName());
+    }
+
+    public void setClasspath(FileCollection classpath) {
+        this.classpath = classpath.getFiles().stream().map(File::toURI).collect(Collectors.toSet());
+    }
+
+    public void setSources(File sourceDirectory) {
+        sources.set(sourceDirectory);
+    }
+
+    @TaskAction
+    void execute(InputChanges inputChanges) throws IOException {
+        Map<String, String> fileNameToFqn = collectRecipes();
+
+        for (FileChange change : inputChanges.getFileChanges(sources)) {
+            File file = change.getFile();
+            //determine FQN
+            String recipeFqn = fileNameToFqn.get(file.getName());
+            if (recipeFqn == null) {
+                continue;
+            }
+            // prepare output file
+            Path targetPath = getOutputDirectory().resolve(recipeFqn + ".yml");
+            if (change.getChangeType() == ChangeType.REMOVED) {
+                Files.delete(targetPath);
+                continue;
+            }
+            Files.createDirectories(targetPath.getParent());
+            // persist content
+            String yaml = String.format(
+                    "type: specs.openrewrite.org/v1beta/origin%n" +
+                            "recipeName: %s%n" +
+                            "recipeUrl: \"%s/tree/main/%s\"%n" +
+                            "recipeLicenseUrl: \"%s\"%n",
+                    recipeFqn, repoBaseUrl, file.getAbsoluteFile(), recipeLicense);
+            Files.write(targetPath, yaml.getBytes());
+        }
+    }
+
+    private @NotNull Map<String, String> collectRecipes() {
+        Map<String, String> fileNameToFqn = new HashMap<>();
+        try (ScanResult scanResult = new ClassGraph().enableClassInfo()
+                .overrideClasspath(classpath)
+                .scan()) {
+            ClassInfoList recipeClasses = scanResult.getSubclasses("org.openrewrite.Recipe");
+            for (ClassInfo recipeClass : recipeClasses) {
+                String file = recipeClass.getSourceFile();
+                String fqn = recipeClass.getName();
+                fileNameToFqn.put(file, fqn);
+            }
+        }
+        return fileNameToFqn;
+    }
+}

--- a/src/main/java/org/openrewrite/gradle/RewriteRecipeOriginTask.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteRecipeOriginTask.java
@@ -73,8 +73,8 @@ public class RewriteRecipeOriginTask extends DefaultTask {
                     "type: specs.openrewrite.org/v1beta/origin%n" +
                             "recipeName: %s%n" +
                             "recipeUrl: \"%s/tree/main/%s\"%n" +
-                            "recipeLicenseUrl: \"%s\"%n",
-                    "recipeLicenseName: \"%s\"%n",
+                            "recipeLicenseUrl: \"%s\"%n" +
+                            "recipeLicenseName: \"%s\"%n",
                     recipeFqn, repoBaseUrl, file.getAbsoluteFile(), recipeLicenseUrl, recipeLicenseName);
             Files.write(targetPath, yaml.getBytes());
         }

--- a/src/main/java/org/openrewrite/gradle/RewriteRecipeOriginTask.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteRecipeOriginTask.java
@@ -19,8 +19,6 @@ import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ClassInfo;
 import io.github.classgraph.ClassInfoList;
 import io.github.classgraph.ScanResult;
-import lombok.Getter;
-import lombok.Setter;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
@@ -41,34 +39,12 @@ import java.util.stream.Collectors;
 @CacheableTask
 public class RewriteRecipeOriginTask extends DefaultTask {
 
-    @Getter(onMethod_ = {
-            @SkipWhenEmpty,
-            @InputDirectory,
-            @PathSensitive(PathSensitivity.NAME_ONLY),
-            @IgnoreEmptyDirectories})
     private final DirectoryProperty sources = getProject().getObjects().directoryProperty();
 
-    @Getter(onMethod_ = @Internal)
     private Set<URI> classpath;
-    @Setter
-    @Getter(onMethod_ = @SkipWhenEmpty)
-    private String recipeLicenseUrl;
-    @Setter
-    @Getter(onMethod_ = @SkipWhenEmpty)
     private String recipeLicenseName;
-    @Setter
-    @Getter(onMethod_ = @SkipWhenEmpty)
+    private String recipeLicenseUrl;
     private String repoBaseUrl;
-
-    @OutputDirectory
-    public Path getOutputDirectory() {
-        return getProject().getBuildDir().toPath().resolve("rewrite/origin")
-                .resolve(sources.get().getAsFile().getName());
-    }
-
-    public void setClasspath(FileCollection classpath) {
-        this.classpath = classpath.getFiles().stream().map(File::toURI).collect(Collectors.toSet());
-    }
 
     public void setSources(File sourceDirectory) {
         sources.set(sourceDirectory);
@@ -98,7 +74,7 @@ public class RewriteRecipeOriginTask extends DefaultTask {
                             "recipeName: %s%n" +
                             "recipeUrl: \"%s/tree/main/%s\"%n" +
                             "recipeLicenseUrl: \"%s\"%n",
-                            "recipeLicenseName: \"%s\"%n",
+                    "recipeLicenseName: \"%s\"%n",
                     recipeFqn, repoBaseUrl, file.getAbsoluteFile(), recipeLicenseUrl, recipeLicenseName);
             Files.write(targetPath, yaml.getBytes());
         }
@@ -117,5 +93,55 @@ public class RewriteRecipeOriginTask extends DefaultTask {
             }
         }
         return fileNameToFqn;
+    }
+
+    @OutputDirectory
+    public Path getOutputDirectory() {
+        return getProject().getBuildDir().toPath().resolve("rewrite/origin")
+                .resolve(sources.get().getAsFile().getName());
+    }
+
+    public void setClasspath(FileCollection classpath) {
+        this.classpath = classpath.getFiles().stream().map(File::toURI).collect(Collectors.toSet());
+    }
+
+    @IgnoreEmptyDirectories
+    @InputDirectory
+    @SkipWhenEmpty
+    @PathSensitive(PathSensitivity.NAME_ONLY)
+    public DirectoryProperty getSources() {
+        return this.sources;
+    }
+
+    @Internal
+    public Set<URI> getClasspath() {
+        return this.classpath;
+    }
+
+    @Input
+    public String getRecipeLicenseName() {
+        return this.recipeLicenseName;
+    }
+
+    @Input
+    public String getRecipeLicenseUrl() {
+        return this.recipeLicenseUrl;
+    }
+
+    @Input
+    public String getRepoBaseUrl() {
+        return this.repoBaseUrl;
+    }
+
+    public void setRecipeLicenseName(String recipeLicenseName) {
+        this.recipeLicenseName = recipeLicenseName;
+    }
+
+    public void setRecipeLicenseUrl(String recipeLicenseUrl) {
+        this.recipeLicenseUrl = recipeLicenseUrl;
+    }
+
+    public void setRepoBaseUrl(String repoBaseUrl) {
+        this.repoBaseUrl = repoBaseUrl;
     }
 }

--- a/src/main/java/org/openrewrite/gradle/RewriteRecipeOriginTask.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteRecipeOriginTask.java
@@ -52,7 +52,10 @@ public class RewriteRecipeOriginTask extends DefaultTask {
     private Set<URI> classpath;
     @Setter
     @Getter(onMethod_ = @SkipWhenEmpty)
-    private String recipeLicense;
+    private String recipeLicenseUrl;
+    @Setter
+    @Getter(onMethod_ = @SkipWhenEmpty)
+    private String recipeLicenseName;
     @Setter
     @Getter(onMethod_ = @SkipWhenEmpty)
     private String repoBaseUrl;
@@ -95,7 +98,8 @@ public class RewriteRecipeOriginTask extends DefaultTask {
                             "recipeName: %s%n" +
                             "recipeUrl: \"%s/tree/main/%s\"%n" +
                             "recipeLicenseUrl: \"%s\"%n",
-                    recipeFqn, repoBaseUrl, file.getAbsoluteFile(), recipeLicense);
+                            "recipeLicenseName: \"%s\"%n",
+                    recipeFqn, repoBaseUrl, file.getAbsoluteFile(), recipeLicenseUrl, recipeLicenseName);
             Files.write(targetPath, yaml.getBytes());
         }
     }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

Add a task and plugin that produces origin information per recipe that contain license information and github urls derived from the projects configuration.

## What's changed?
<!-- A brief description of the changes in this pull request -->
A new, not yet integrated plugin.

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
provide information to pickup by the openrewrite/rewrite Enviroment

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
first gradle pugin/task ever, so basic stuff..

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
