### PR TITLE
Add License to manifest to make it easier to update docs

### DIFF
--- a/src/main/java/org/openrewrite/gradle/ModerneProprietaryLicensePlugin.java
+++ b/src/main/java/org/openrewrite/gradle/ModerneProprietaryLicensePlugin.java
@@ -25,6 +25,8 @@ import org.gradle.api.publish.maven.internal.publication.DefaultMavenPom;
 import org.gradle.jvm.tasks.Jar;
 import org.openrewrite.internal.lang.Nullable;
 
+import java.util.Map;
+
 public class ModerneProprietaryLicensePlugin implements Plugin<Project> {
 
     @Override
@@ -48,6 +50,9 @@ public class ModerneProprietaryLicensePlugin implements Plugin<Project> {
         PublishingExtension publishing = project.getExtensions().getByType(PublishingExtension.class);
         publishing.publications(publications ->
                 publications.withType(MavenPublication.class, p -> configureLicense(p, emptySourcesJar)));
+
+        project.getTasks().withType(Jar.class).configureEach(jar ->
+                jar.getManifest().attributes(Map.of("License", "Moderne Proprietary License")));
     }
 
     private void configureLicense(MavenPublication publication, @Nullable Jar sourcesJar) {

--- a/src/main/java/org/openrewrite/gradle/ModerneSourceAvailableLicensePlugin.java
+++ b/src/main/java/org/openrewrite/gradle/ModerneSourceAvailableLicensePlugin.java
@@ -21,6 +21,9 @@ import org.gradle.api.Project;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.maven.internal.publication.DefaultMavenPom;
+import org.gradle.jvm.tasks.Jar;
+
+import java.util.Map;
 
 public class ModerneSourceAvailableLicensePlugin implements Plugin<Project> {
 
@@ -29,6 +32,9 @@ public class ModerneSourceAvailableLicensePlugin implements Plugin<Project> {
         project.getPlugins().apply(MavenBasePublishPlugin.class);
         PublishingExtension publishing = project.getExtensions().getByType(PublishingExtension.class);
         publishing.publications(publications -> publications.withType(MavenPublication.class, this::configureLicense));
+
+        project.getTasks().withType(Jar.class).configureEach(jar ->
+                jar.getManifest().attributes(Map.of("License", "Moderne Source Available License")));
     }
 
     private void configureLicense(MavenPublication publication) {

--- a/src/main/java/org/openrewrite/gradle/RewriteLicensePlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteLicensePlugin.java
@@ -23,11 +23,9 @@ import nl.javadude.gradle.plugins.license.LicenseExtension;
 import nl.javadude.gradle.plugins.license.LicensePlugin;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.jvm.tasks.Jar;
 
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.Optional;
+import java.util.*;
 
 public class RewriteLicensePlugin implements Plugin<Project> {
 
@@ -44,6 +42,9 @@ public class RewriteLicensePlugin implements Plugin<Project> {
             ((org.gradle.api.plugins.ExtraPropertiesExtension) task.getExtensions().getByName("ext"))
                     .set("year", Calendar.getInstance().get(Calendar.YEAR));
         });
+
+        project.getTasks().withType(Jar.class).configureEach(jar ->
+                jar.getManifest().attributes(Map.of("License", "Apache License Version 2.0")));
 
         project.getExtensions().configure(LicenseExtension.class, ext -> {
             ext.setSkipExistingHeaders(Optional


### PR DESCRIPTION
Alternative and minimal implementation; confirmed to work for proprietary recipes already.

- Closes https://github.com/openrewrite/rewrite-build-gradle-plugin/pull/83