### PR TITLE
Use Java 21 for tests going forward

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -172,7 +172,7 @@ configurations.all {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 

--- a/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
@@ -49,7 +49,7 @@ public class RewriteJavaPlugin implements Plugin<Project> {
         });
 
         project.getExtensions().configure(JavaPluginExtension.class, java -> java.toolchain(toolchain -> toolchain.getLanguageVersion()
-                .set(JavaLanguageVersion.of(17))));
+                .set(JavaLanguageVersion.of(21))));
 
         project.getConfigurations().all(config -> config.resolutionStrategy(strategy ->
                 strategy.cacheDynamicVersionsFor(0, "seconds")));


### PR DESCRIPTION
## What's your motivation?
Java 21 is almost two years old by now, Java 25 is around the corner, and this way we can already take advantage of newer language features to improve the tests & recipes.

## Have you considered any alternatives or workarounds?
Continue to use Java 17: slightly higher adoption, but also somewhat dated by now as compared to 21.
Java 24+ considered, but relatively little added benefit for now, and a lot less widely adopted so far.

## Any additional context
We've already been [running the tests on Java 21](https://github.com/openrewrite/gh-automation/blob/4ca69e2ea0a8a5d4031ea67f0dad746e131214aa/.github/workflows/ci-gradle.yml#L7-L11) since October 2023 https://github.com/openrewrite/gh-automation/commit/7f4138434bce8cca5c7b0b55ddacc19553f59442
