### PR TITLE
Build on Java 21, and target Java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 21
       - uses: gradle/actions/setup-gradle@v4
       - name: build
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} build

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 21
       - name: setup-plugin-pTML
         run: ./rewrite-gradle-plugin/gradlew --project-dir rewrite-gradle-plugin pTML
       - name: setup-java-${{ matrix.java }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 21
 
       - uses: gradle/actions/setup-gradle@v4
       - name: publish-candidate

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -177,7 +177,7 @@ java {
 }
 
 tasks.named<JavaCompile>("compileJava") {
-    options.release.set(11)
+    options.release.set(17)
 }
 
 val rewriteVersion = "8.49.0"

--- a/src/main/java/org/openrewrite/gradle/RecipeDependenciesTypeTableTask.java
+++ b/src/main/java/org/openrewrite/gradle/RecipeDependenciesTypeTableTask.java
@@ -65,7 +65,7 @@ public class RecipeDependenciesTypeTableTask extends DefaultTask {
                             .substring(artifact.length() + 1)
                             .replaceAll(".jar$", "");
                     writer.jar(group, artifact, version).write(dependency.getValue().toPath());
-                    getLogger().info(String.format("Wrote %s:%s:%s to %s", group, artifact, version, tsvFile));
+                    getLogger().info("Wrote %s:%s:%s to %s".formatted(group, artifact, version, tsvFile));
                 }
             }
         }


### PR DESCRIPTION
## What's your motivation?
We already required Java 11 because of a license plugin update; Java 17 makes most sense as that has text blocks.

## Have you considered any alternatives or workarounds?
We could continue to use Java 11, but the expectation is that folks are able to upgrade to at least 17 with ease.

## Any additional context
- Follows https://github.com/openrewrite/rewrite-build-gradle-plugin/pull/89