### PR TITLE
Prepare the move for sonatype central

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         if: github.event_name != 'pull_request'
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} snapshot :publishPluginMavenPublicationToSonatypeRepository -x test -x publishPlugins
         env:
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_TOKEN }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_TOKEN }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.OSSRH_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.OSSRH_SIGNING_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,10 @@ configure<org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension> {
 
 nexusPublishing {
     repositories {
-        sonatype()
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+        }
     }
 }
 
@@ -180,7 +183,7 @@ tasks.named<JavaCompile>("compileJava") {
     options.release.set(17)
 }
 
-val rewriteVersion = "8.49.0"
+val rewriteVersion = "8.49.0" //TODO: update this to the just released version before publishing!
 
 dependencies {
     compileOnly("org.openrewrite.gradle.tooling:model:latest.release")

--- a/src/main/java/org/openrewrite/gradle/RewriteDependencyRepositoriesPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteDependencyRepositoriesPlugin.java
@@ -28,7 +28,7 @@ public class RewriteDependencyRepositoriesPlugin implements Plugin<Project> {
         if (!project.hasProperty("releasing")) {
             repos.add(repos.mavenLocal(repo -> repo.content(content ->
                     content.excludeVersionByRegex(".+", ".+", ".+-rc[-]?[0-9]*"))));
-            repos.add(repos.maven(repo -> repo.setUrl("https://oss.sonatype.org/content/repositories/snapshots/")));
+            repos.add(repos.maven(repo -> repo.setUrl("https://central.sonatype.com/repository/maven-snapshots/")));
         }
 
         repos.add(repos.mavenCentral(repo -> repo.content(content ->

--- a/src/main/java/org/openrewrite/gradle/RewriteRootProjectPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteRootProjectPlugin.java
@@ -17,11 +17,15 @@ package org.openrewrite.gradle;
 
 import io.github.gradlenexus.publishplugin.NexusPublishExtension;
 import io.github.gradlenexus.publishplugin.NexusPublishPlugin;
+import io.github.gradlenexus.publishplugin.NexusRepository;
 import nebula.plugin.release.NetflixOssStrategies;
 import nebula.plugin.release.ReleasePlugin;
 import nebula.plugin.release.git.base.ReleasePluginExtension;
+import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+
+import java.net.URI;
 
 public class RewriteRootProjectPlugin implements Plugin<Project> {
 
@@ -30,7 +34,11 @@ public class RewriteRootProjectPlugin implements Plugin<Project> {
         project.getPlugins().apply(ReleasePlugin.class);
         project.getPlugins().apply(NexusPublishPlugin.class);
 
-        project.getExtensions().configure(NexusPublishExtension.class, ext -> ext.getRepositories().sonatype());
+        project.getExtensions().configure(NexusPublishExtension.class, ext ->
+                ext.getRepositories().sonatype(nexusRepository -> {
+                    nexusRepository.getNexusUrl().set(URI.create("https://ossrh-staging-api.central.sonatype.com/service/local/"));
+                    nexusRepository.getSnapshotRepositoryUrl().set(URI.create("https://central.sonatype.com/repository/maven-snapshots/"));
+        }));
 
         if (project.getExtensions().findByType(ReleasePluginExtension.class) != null) {
             project.getExtensions().configure(ReleasePluginExtension.class, ext ->


### PR DESCRIPTION
DO NOT MERGE THIS YET!

## What's changed?
Added support to publish to sonatype central snapshot repo. 
Goal is that this is published when we have released OR completely.
All snapshots afterwards should then start using the new destination. 
Before merging this one then we have to update the TODO with the new version of OR.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
