### PR TITLE
Expose property for defining output directory for type table file

### DIFF
--- a/src/test/java/org/openrewrite/gradle/RecipeDependenciesTypeTableTaskTest.java
+++ b/src/test/java/org/openrewrite/gradle/RecipeDependenciesTypeTableTaskTest.java
@@ -17,7 +17,6 @@ package org.openrewrite.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
-import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,7 +38,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.gradle.testkit.runner.TaskOutcome.FAILED;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.openrewrite.gradle.UpdateJavaCompatibility.CompatibilityType.source;
 
 class RecipeDependenciesTypeTableTaskTest {
     @TempDir

--- a/src/test/java/org/openrewrite/gradle/RecipeDependenciesTypeTableTaskTest.java
+++ b/src/test/java/org/openrewrite/gradle/RecipeDependenciesTypeTableTaskTest.java
@@ -36,8 +36,10 @@ import java.util.Collection;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.gradle.testkit.runner.TaskOutcome.FAILED;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.openrewrite.gradle.UpdateJavaCompatibility.CompatibilityType.source;
 
 class RecipeDependenciesTypeTableTaskTest {
     @TempDir
@@ -54,7 +56,7 @@ class RecipeDependenciesTypeTableTaskTest {
 
     @Test
     void multipleVersionsOfGuava() throws Exception {
-        BuildResult result = createSourceFiles("""
+        createGradleBuildFiles("""
           plugins {
               id 'org.openrewrite.build.recipe-library-base'
           }
@@ -67,6 +69,7 @@ class RecipeDependenciesTypeTableTaskTest {
           }
           """);
 
+        BuildResult result = runTypeTableTaskAndSucceed();
         assertEquals(SUCCESS, requireNonNull(result.task(":createTypeTable")).getOutcome());
 
         // Assert type table created
@@ -83,7 +86,7 @@ class RecipeDependenciesTypeTableTaskTest {
 
     @Test
     void resolveFivePlusToActualVersion() throws Exception {
-        BuildResult result = createSourceFiles("""
+        createGradleBuildFiles("""
           plugins {
               id 'org.openrewrite.build.recipe-library-base'
           }
@@ -95,6 +98,7 @@ class RecipeDependenciesTypeTableTaskTest {
           }
           """);
 
+        BuildResult result = runTypeTableTaskAndSucceed();
         assertEquals(SUCCESS, requireNonNull(result.task(":createTypeTable")).getOutcome());
 
         // Assert type table created
@@ -109,15 +113,121 @@ class RecipeDependenciesTypeTableTaskTest {
         assertThat(table.load("spring-core-5.3")).isDirectoryRecursivelyContaining("glob:**/Order.class");
     }
 
-    private BuildResult createSourceFiles(@Language("gradle") String source) throws IOException {
+    @Test
+    void usesDefaultIfMultipleResourcesDirectoriesHaveBeenDefined() throws Exception {
+        createGradleBuildFiles("""
+          plugins {
+              id 'java'
+              id 'org.openrewrite.build.recipe-library-base'
+          }
+          repositories {
+              mavenCentral()
+          }
+          recipeDependencies {
+              parserClasspath 'com.google.guava:guava:30.1-jre'
+          }
+          sourceSets {
+              main {
+                  resources.srcDir('build/custom-resources')
+              }
+          }
+          """);
+
+        BuildResult result = runTypeTableTaskAndSucceed();
+        assertEquals(SUCCESS, requireNonNull(result.task(":createTypeTable")).getOutcome());
+
+        // Assert type table created
+        File tsvFile = new File(projectDir, "src/main/resources/" + TypeTable.DEFAULT_RESOURCE_PATH);
+        assertThat(tsvFile)
+          .isFile()
+          .isReadable()
+          .isNotEmpty();
+
+        // Load classes from the type table
+        TypeTable table = createTypeTable(tsvFile, "guava");
+        assertThat(table.load("guava")).isDirectoryRecursivelyContaining("glob:**/Optional.class");
+    }
+
+    @Test
+    void canSelectCustomResourcesDirectory() throws Exception {
+        createGradleBuildFiles("""
+          plugins {
+              id 'java'
+              id 'org.openrewrite.build.recipe-library-base'
+          }
+          repositories {
+              mavenCentral()
+          }
+          recipeDependencies {
+              parserClasspath 'com.google.guava:guava:30.1-jre'
+          }
+          sourceSets.main {
+              resources.srcDir('very/custom')
+          }
+          createTypeTable {
+              targetDir = layout.projectDirectory.dir('very/custom')
+          }
+          """);
+
+        BuildResult result = runTypeTableTaskAndSucceed();
+        assertEquals(SUCCESS, requireNonNull(result.task(":createTypeTable")).getOutcome());
+
+        // Assert type table created
+        File tsvFile = new File(projectDir, "very/custom/" + TypeTable.DEFAULT_RESOURCE_PATH);
+        assertThat(tsvFile)
+          .isFile()
+          .isReadable()
+          .isNotEmpty();
+
+        // Load classes from the type table
+        TypeTable table = createTypeTable(tsvFile, "guava");
+        assertThat(table.load("guava")).isDirectoryRecursivelyContaining("glob:**/Optional.class");
+    }
+
+    @Test
+    void throwsExceptionForNonExistentResourcesDirectory() throws Exception {
+        createGradleBuildFiles("""
+          plugins {
+              id 'org.openrewrite.build.recipe-library-base'
+          }
+          repositories {
+              mavenCentral()
+          }
+          recipeDependencies {
+              parserClasspath 'com.google.guava:guava:30.1-jre'
+          }
+          createTypeTable {
+              targetDir = layout.projectDirectory.dir('very/custom')
+          }
+          """);
+
+        BuildResult result = runTypeTableTaskAndFail();
+        assertEquals(FAILED, requireNonNull(result.task(":createTypeTable")).getOutcome());
+
+        File tsvFile = new File(projectDir, "very/custom/" + TypeTable.DEFAULT_RESOURCE_PATH);
+        assertThat(tsvFile)
+          .doesNotExist();
+    }
+
+    private void createGradleBuildFiles(String buildFileContent) throws IOException {
         Files.writeString(settingsFile.toPath(), "rootProject.name = 'my-project'");
-        Files.writeString(buildFile.toPath(), source);
+        Files.writeString(buildFile.toPath(), buildFileContent);
+    }
+
+    private BuildResult runTypeTableTaskAndSucceed() {
+        return createGradleRunner().build();
+    }
+
+    private BuildResult runTypeTableTaskAndFail() {
+        return createGradleRunner().buildAndFail();
+    }
+
+    private GradleRunner createGradleRunner() {
         return GradleRunner.create()
           .withProjectDir(projectDir)
           .withArguments("createTypeTable", "--info", "--stacktrace")
           .withPluginClasspath()
-          .withDebug(true)
-          .build();
+          .withDebug(true);
     }
 
     private static @Nullable TypeTable createTypeTable(File tsvFile, String guava) throws Exception {


### PR DESCRIPTION
## What's changed?

Introduces a property that lets the end user select the target directory to generate the type table file in.

## What's your motivation?

Projects can define multiple resources directories for the `main` sources set. This will lead to generating the type table file per resources directory. The `processResources` task would throw an exception when copying the file twice as it would override it.

```
> Task :createTypeTable
> Task :processResources FAILED

...

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':processResources'.
> Entry META-INF/rewrite/classpath.tsv.zip is a duplicate but no duplicate handling strategy has been set. Please refer to https://docs.gradle.org/8.13/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details.
```
