### PR TITLE
Add suppression for new CVE found in spring-asm

### DIFF
--- a/suppressions.xml
+++ b/suppressions.xml
@@ -105,6 +105,7 @@
         <cve>CVE-2022-22970</cve>
         <cve>CVE-2014-3625</cve>
         <cve>CVE-2014-1904</cve>
+        <cve>CVE-2024-22259</cve>
     </suppress>
     <suppress until="2025-07-01Z">
         <notes><![CDATA[


### PR DESCRIPTION
This CVE surfaces from `gradle.plugin.com.hierynomus.gradle.plugins:license-gradle-plugin` using `com.mycila:license-maven-plugin:3.0` which only uses a property resolving util and not the vulnerable `UriComponentsBuilder`