### PR TITLE
Pin JUnit to 5.+

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -224,7 +224,7 @@ dependencies {
     implementation("io.github.classgraph:classgraph:latest.release")
     implementation("org.eclipse.jgit:org.eclipse.jgit:latest.release")
 
-    testImplementation(platform("org.junit:junit-bom:latest.release"))
+    testImplementation(platform("org.junit:junit-bom:5.+"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")

--- a/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
@@ -81,7 +81,7 @@ public class RewriteJavaPlugin implements Plugin<Project> {
         deps.add("implementation", "org.jetbrains:annotations:latest.release");
         deps.add("compileOnly", "com.google.code.findbugs:jsr305:latest.release");
 
-        deps.add("testImplementation", deps.platform("org.junit:junit-bom:latest.release"));
+        deps.add("testImplementation", deps.platform("org.junit:junit-bom:5.+"));
         deps.add("testImplementation", "org.junit.jupiter:junit-jupiter-api");
         deps.add("testImplementation", "org.junit.jupiter:junit-jupiter-params");
         deps.add("testRuntimeOnly", "org.junit.jupiter:junit-jupiter-engine");


### PR DESCRIPTION
## What's changed?

Pinning the JUnit version to 5 major.

## What's your motivation?

JUnit has just released `6.0.0-M1` an hour ago. And these versions require Java 17, which we are not ready to take.
