### PR TITLE
Remove AuthorAttribution from plugin

### DIFF
--- a/src/main/java/org/openrewrite/gradle/RewriteLanguageLibraryPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteLanguageLibraryPlugin.java
@@ -30,6 +30,5 @@ public class RewriteLanguageLibraryPlugin implements Plugin<Project> {
         project.getExtensions().create("recipeDependencies", RecipeDependenciesExtension.class);
         project.getTasks().register("createTypeTable", RecipeDependenciesTypeTableTask.class);
         project.getPlugins().apply(RewritePublishPlugin.class);
-        project.getPlugins().apply(RewriteRecipeAuthorAttributionPlugin.class);
     }
 }


### PR DESCRIPTION
Removing the author attribution as we do not use the details anymore to speed up the build/ci time.