### PR TITLE
Source set support for the recipe dependencies plugin

### DIFF
--- a/src/main/java/org/openrewrite/gradle/RecipeDependenciesExtension.java
+++ b/src/main/java/org/openrewrite/gradle/RecipeDependenciesExtension.java
@@ -50,11 +50,6 @@ public class RecipeDependenciesExtension {
         addDependencyForSourceSet("test", dependencyNotation);
     }
 
-    @SuppressWarnings("unused")
-    public void integrationTestParserClasspath(String dependencyNotation) {
-        addDependencyForSourceSet("integrationTest", dependencyNotation);
-    }
-
     /**
      * Add a dependency to the parser classpath for a specific source set.
      * This is useful for custom source sets not covered by the convenience methods above.

--- a/src/main/java/org/openrewrite/gradle/RewriteLanguageLibraryPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteLanguageLibraryPlugin.java
@@ -17,6 +17,9 @@ package org.openrewrite.gradle;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.tasks.TaskProvider;
 
 public class RewriteLanguageLibraryPlugin implements Plugin<Project> {
 
@@ -27,8 +30,54 @@ public class RewriteLanguageLibraryPlugin implements Plugin<Project> {
         project.getPlugins().apply(RewriteLicensePlugin.class);
         project.getPlugins().apply(RewriteMetadataPlugin.class);
         project.getPlugins().apply(RewriteBuildInputLoggingPlugin.class);
+
         project.getExtensions().create("recipeDependencies", RecipeDependenciesExtension.class);
-        project.getTasks().register("createTypeTable", RecipeDependenciesTypeTableTask.class);
+
+        // Register base task for backward compatibility
+        project.getTasks().register("createTypeTable", RecipeDependenciesTypeTableTask.class, task -> {
+            task.getSourceSetName().convention("main");
+        });
+
+        // Configure source set specific tasks when Java plugin is applied
+        project.getPlugins().withType(JavaPlugin.class, javaPlugin -> {
+            JavaPluginExtension javaExt = project.getExtensions().getByType(JavaPluginExtension.class);
+
+            javaExt.getSourceSets().all(sourceSet -> {
+                String sourceSetName = sourceSet.getName();
+
+                // Register task for each source set
+                String taskName = sourceSetName.equals("main") ? "createTypeTable" :
+                        "create" + capitalize(sourceSetName) + "TypeTable";
+
+                if (!sourceSetName.equals("main")) {
+                    TaskProvider<RecipeDependenciesTypeTableTask> taskProvider = project.getTasks().register(taskName, RecipeDependenciesTypeTableTask.class, task -> {
+                        task.getSourceSetName().convention(sourceSetName);
+                        task.getTargetDir().convention(
+                            project.getLayout().getProjectDirectory().dir("src/" + sourceSetName + "/resources")
+                        );
+                    });
+
+                    // Wire up with processResources task
+                    String processResourcesTaskName = sourceSet.getProcessResourcesTaskName();
+                    project.getTasks().named(processResourcesTaskName).configure(processTask ->
+                        processTask.dependsOn(taskProvider)
+                    );
+                } else {
+                    // Wire up main task with processResources
+                    project.getTasks().named("processResources").configure(processTask ->
+                        processTask.dependsOn("createTypeTable")
+                    );
+                }
+            });
+        });
+
         project.getPlugins().apply(RewritePublishPlugin.class);
+    }
+
+    private static String capitalize(String str) {
+        if (str.isEmpty()) {
+            return str;
+        }
+        return str.substring(0, 1).toUpperCase() + str.substring(1);
     }
 }

--- a/src/test/java/org/openrewrite/gradle/RecipeDependenciesTypeTableTaskTest.java
+++ b/src/test/java/org/openrewrite/gradle/RecipeDependenciesTypeTableTaskTest.java
@@ -17,7 +17,7 @@ package org.openrewrite.gradle;
 
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
-import org.jspecify.annotations.Nullable;
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -299,7 +299,7 @@ class RecipeDependenciesTypeTableTaskTest {
         assertThat(table.load("assertj-core")).isDirectoryRecursivelyContaining("glob:**/Assertions.class");
     }
 
-    private void createGradleBuildFiles(String buildFileContent) throws IOException {
+    private void createGradleBuildFiles(@Language("gradle") String buildFileContent) throws IOException {
         Files.writeString(settingsFile.toPath(), "rootProject.name = 'my-project'");
         Files.writeString(buildFile.toPath(), buildFileContent);
     }


### PR DESCRIPTION
1. `RecipeDependenciesExtension`:
   - Added support for multiple source sets with a Map<String, Set<String>> to track dependencies per source set
   - Kept the original `parserClasspath()` method for backwards compatibility (targets "main")
   - Added `testParserClasspath()` for the test source set
   - Added a generic `parserClasspath(String sourceSetName, String dependency)` method for custom source sets
2. `RecipeDependenciesTypeTableTask`:
   - Added a `sourceSetName` property to specify which source set to process
   - Updated the validation logic to check against the correct source set's resource directories
   - Defaults to "main" for backwards compatibility
3. Plugin Updates:
   - Both `RewriteRecipeLibraryBasePlugin` and `RewriteLanguageLibraryPlugin` now:
    - Create tasks dynamically for each source set (e.g., `createTestTypeTable`)
    - Wire up tasks with the appropriate `processResources` tasks
    - Set correct default directories for each source set
4. Tests:
   - Added tests for the test source set functionality
   - Added tests for custom source sets using the generic method
   - All existing tests still pass

Key Features:

✅ Fully backwards-compatible - Existing `parserClasspath()` calls work unchanged
✅ Gradle-ish conventions - Follows patterns like `testImplementation`
✅ Auto-wiring - Tasks automatically depend on `processResources`
✅ Flexible - Supports both common source sets and custom ones via the generic method

Usage Examples:

```gradle
recipeDependencies {
    // Main source set (backwards compatible)
    parserClasspath("jakarta.enterprise:jakarta.enterprise.cdi-api:3.0.0-M4")

    // Test source set
    testParserClasspath("org.junit.jupiter:junit-jupiter-api:5.10.0")
}
```
