### PR TITLE
Make central analyzer and ossIndex username and password configurable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,9 @@ configure<org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension> {
     failBuildOnCVSS = System.getenv("FAIL_BUILD_ON_CVSS")?.toFloatOrNull() ?: 9.0F
     format = System.getenv("DEPENDENCY_CHECK_FORMAT") ?: "HTML"
     nvd.apiKey = System.getenv("NVD_API_KEY")
+    analyzers.centralEnabled = System.getenv("CENTRAL_ANALYZER_ENABLED").toBoolean()
+    analyzers.ossIndex.username = System.getenv("OSSINDEX_USERNAME")
+    analyzers.ossIndex.password = System.getenv("OSSINDEX_PASSWORD")
     suppressionFile = "suppressions.xml"
 }
 

--- a/src/main/java/org/openrewrite/gradle/RewriteDependencyCheckPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteDependencyCheckPlugin.java
@@ -49,6 +49,9 @@ public class RewriteDependencyCheckPlugin implements Plugin<Project> {
             ext.setFailBuildOnCVSS(failBuildOnCVSS);
             ext.setFormat(format);
             ext.getNvd().setApiKey(System.getenv("NVD_API_KEY"));
+            ext.getAnalyzers().setCentralEnabled(Boolean.valueOf(System.getenv("CENTRAL_ANALYZER_ENABLED")));
+            ext.getAnalyzers().getOssIndex().setUsername(System.getenv("OSSINDEX_USERNAME"));
+            ext.getAnalyzers().getOssIndex().setPassword(System.getenv("OSSINDEX_PASSWORD"));
 
         });
 


### PR DESCRIPTION
Central analyzer reaches out to `search.maven.org` which often has trouble, hence why we want to be able to disable it.
ossIndex now requires authentication so added those as well