### PR TITLE
Use Java 25 toolchain going forward

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
       - uses: gradle/actions/setup-gradle@v5
       - name: build
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 25
 
       - uses: gradle/actions/setup-gradle@v5
       - name: publish-candidate

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out/
 !*/src/**/build
 .gradle/
 .idea/
+.claude/settings.local.json

--- a/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
@@ -58,7 +58,7 @@ public class RewriteJavaPlugin implements Plugin<Project> {
         });
 
         project.getExtensions().configure(JavaPluginExtension.class, java ->
-                java.toolchain(toolchain -> toolchain.getLanguageVersion().set(JavaLanguageVersion.of(21))));
+                java.toolchain(toolchain -> toolchain.getLanguageVersion().set(JavaLanguageVersion.of(25))));
 
         project.getConfigurations().all(config -> config.resolutionStrategy(strategy ->
                 strategy.cacheDynamicVersionsFor(0, "seconds")));


### PR DESCRIPTION
- Ties in with https://github.com/openrewrite/gh-automation/pull/86

Figured since we now use the Kotlin v2 compiler, we can finally run our CI on Java 25, and move the tests over to Java 25.