### PR TITLE
Include root project suppressions in multimodule builds

### DIFF
--- a/src/main/java/org/openrewrite/gradle/RewriteDependencyCheckPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteDependencyCheckPlugin.java
@@ -80,13 +80,18 @@ public class RewriteDependencyCheckPlugin implements Plugin<Project> {
             throw new UncheckedIOException("Failed to copy suppressions.xml", e);
         }
 
+        File rootSuppressionsFile = new File(project.getRootProject().getProjectDir(), "suppressions.xml");
+
         project.getExtensions().configure(DependencyCheckExtension.class, ext -> {
             List<String> suppressionFiles = new ArrayList<>();
             suppressionFiles.add(sharedSuppressionsFile.getAbsolutePath());
             project.getLogger().info("Adding shared suppressions file: {}", sharedSuppressionsFile.getAbsolutePath());
-            if (projectSuppressionsFile.exists()) {
-                project.getLogger().info("Adding project suppressions file: {}",
-                        projectSuppressionsFile.getAbsolutePath());
+            if (rootSuppressionsFile.exists()) {
+                project.getLogger().info("Adding root project suppressions file: {}", rootSuppressionsFile.getAbsolutePath());
+                suppressionFiles.add(rootSuppressionsFile.getAbsolutePath());
+            }
+            if (projectSuppressionsFile.exists() && !projectSuppressionsFile.equals(rootSuppressionsFile)) {
+                project.getLogger().info("Adding project suppressions file: {}", projectSuppressionsFile.getAbsolutePath());
                 suppressionFiles.add(projectSuppressionsFile.getAbsolutePath());
             }
             ext.setSuppressionFiles(suppressionFiles);


### PR DESCRIPTION
## Summary
- Subprojects in multimodule builds now pick up the root project's `suppressions.xml` in addition to the shared (JAR-bundled) and their own project-level suppression files
- Previously only `project.getProjectDir()` was checked, which for subprojects points to their own directory, missing root-level suppressions
- Avoids duplicate entries when the project *is* the root project via `!projectSuppressionsFile.equals(rootSuppressionsFile)`

## Test plan
- [ ] Apply plugin to a multimodule project with `suppressions.xml` at the root
- [ ] Run dependency-check with `--info` and verify all subprojects log "Adding root project suppressions file"
- [ ] Confirm CVEs suppressed at root level no longer appear in subproject reports