### PR TITLE
Pass project package name to completeness validator

### DIFF
--- a/src/main/java/org/openrewrite/gradle/RecipeMarketplaceCsvValidateCompletenessTask.java
+++ b/src/main/java/org/openrewrite/gradle/RecipeMarketplaceCsvValidateCompletenessTask.java
@@ -49,6 +49,9 @@ public abstract class RecipeMarketplaceCsvValidateCompletenessTask extends Defau
     @Internal
     public abstract RegularFileProperty getCsvFile();
 
+    @Input
+    public abstract org.gradle.api.provider.Property<String> getProjectPackageName();
+
     @InputFile
     @PathSensitive(PathSensitivity.NONE)
     public abstract RegularFileProperty getRecipeJar();
@@ -84,11 +87,13 @@ public abstract class RecipeMarketplaceCsvValidateCompletenessTask extends Defau
         getLogger().info("Validating recipes.csv completeness at: {}", csvPath.toAbsolutePath());
         getLogger().info("Against recipe JAR: {}", recipeJarPath);
 
-        // Validate completeness
+        // Validate completeness, passing the project's package name so that
+        // cross-package recipes (from dependency JARs) are excluded from the phantom check
         RecipeMarketplaceCompletenessValidator validator = new RecipeMarketplaceCompletenessValidator();
         Validated<RecipeMarketplace> validation = validator.validate(
                 new RecipeMarketplaceReader().fromCsv(csvPath),
-                jarScanningEnvironment(recipeJarPath));
+                jarScanningEnvironment(recipeJarPath),
+                getProjectPackageName().getOrNull());
 
         if (validation.isInvalid()) {
             Map<String, List<Validated.Invalid<RecipeMarketplace>>> byMessage = validation.failures().stream()

--- a/src/main/java/org/openrewrite/gradle/RewriteRecipeMarketplacePlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteRecipeMarketplacePlugin.java
@@ -60,6 +60,8 @@ public class RewriteRecipeMarketplacePlugin implements Plugin<Project> {
                         task.getRecipeJar().convention(project.getTasks().named(JavaPlugin.JAR_TASK_NAME, Jar.class).flatMap(Jar::getArchiveFile));
                     }
 
+                    task.getProjectPackageName().convention(project.provider(() ->
+                            project.getGroup() + ":" + project.getName()));
                     task.getCsvFile().convention(recipesCsvFile);
                 });
 

--- a/src/test/java/org/openrewrite/gradle/RecipeMarketplaceCsvValidateCompletenessTaskTest.java
+++ b/src/test/java/org/openrewrite/gradle/RecipeMarketplaceCsvValidateCompletenessTaskTest.java
@@ -255,6 +255,29 @@ class RecipeMarketplaceCsvValidateCompletenessTaskTest {
         }
     }
 
+    @Test
+    void passesWhenCsvContainsCrossPackageRecipe() throws Exception {
+        createSimpleRecipeProject();
+        csvFile.getParentFile().mkdirs();
+        // CSV contains a recipe from this project AND one from a different package (a dependency)
+        Files.writeString(csvFile.toPath(),
+          """
+          ecosystem,packageName,name,displayName,description
+          maven,org.example:test-recipe-project,org.example.TestRecipe,Test recipe,A test recipe.
+          maven,org.openrewrite:rewrite-java,org.openrewrite.java.SomeDependencyRecipe,Dependency recipe,A recipe from a dependency JAR.
+          """);
+
+        BuildResult result = GradleRunner.create()
+          .withProjectDir(projectDir)
+          .withArguments("recipeCsvValidateCompleteness", "--info", "--stacktrace")
+          .withPluginClasspath()
+          .withDebug(true)
+          .build();
+
+        assertThat(requireNonNull(result.task(":recipeCsvValidateCompleteness")).getOutcome()).isEqualTo(SUCCESS);
+        assertThat(result.getOutput()).contains("Recipe marketplace CSV completeness validation passed");
+    }
+
     private void createCsvMatchingJar() throws IOException {
         csvFile.getParentFile().mkdirs();
         Files.writeString(csvFile.toPath(),


### PR DESCRIPTION
## Background / problem

When a recipe JAR's `recipes.csv` contains entries from dependency JARs (with a different `packageName`), the completeness validator flags them as "phantom recipes" because `scanJar` only scans the project's own JAR. This prevents recipe authors from exposing recipes from their dependencies in their own marketplace listing.

## Solution

The `recipeCsvValidateCompleteness` task now passes the project's `group:name` as the `projectPackageName` to the completeness validator. This allows the validator to skip the phantom recipe check for cross-package recipes, since they intentionally reference recipes from dependency JARs that aren't part of the project's own scan.

- Depends on the `validate(csv, env, projectPackageName)` overload added in https://github.com/openrewrite/rewrite/pull/7331.

## Test plan

- [x] New test `passesWhenCsvContainsCrossPackageRecipe` verifies that a CSV with a recipe from a different package passes validation
- [x] All existing completeness validation tests continue to pass