### PR TITLE
Suppress OpenTelemetry Go CVEs (false positives for Java packages)

### DIFF
--- a/src/main/resources/suppressions.xml
+++ b/src/main/resources/suppressions.xml
@@ -56,4 +56,22 @@
         <packageUrl regex="true">^pkg:maven/org\.openrewrite\.recipe/rewrite-openapi@.*$</packageUrl>
         <cve>CVE-2024-25712</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+            False positive. CVE-2026-39883 is for the Go opentelemetry-go SDK (PATH hijacking
+            of the kenv command on BSD). The Java io.opentelemetry packages are unaffected.
+            Added: 2026-04-16
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry/opentelemetry-.*@.*$</packageUrl>
+        <cve>CVE-2026-39883</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            False positive. CVE-2026-39882 is for Go OTLP HTTP exporters (unbounded response
+            body reading). The Java io.opentelemetry packages are unaffected.
+            Added: 2026-04-16
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry/opentelemetry-.*@.*$</packageUrl>
+        <cve>CVE-2026-39882</cve>
+    </suppress>
 </suppressions>

--- a/src/main/resources/suppressions.xml
+++ b/src/main/resources/suppressions.xml
@@ -56,7 +56,7 @@
         <packageUrl regex="true">^pkg:maven/org\.openrewrite\.recipe/rewrite-openapi@.*$</packageUrl>
         <cve>CVE-2024-25712</cve>
     </suppress>
-    <suppress>
+    <suppress until="2026-05-01Z">
         <notes><![CDATA[
             False positive. CVE-2026-39883 is for the Go opentelemetry-go SDK (PATH hijacking
             of the kenv command on BSD). The Java io.opentelemetry packages are unaffected.
@@ -65,7 +65,7 @@
         <packageUrl regex="true">^pkg:maven/io\.opentelemetry/opentelemetry-.*@.*$</packageUrl>
         <cve>CVE-2026-39883</cve>
     </suppress>
-    <suppress>
+    <suppress until="2026-05-01Z">
         <notes><![CDATA[
             False positive. CVE-2026-39882 is for Go OTLP HTTP exporters (unbounded response
             body reading). The Java io.opentelemetry packages are unaffected.


### PR DESCRIPTION
## Summary
- Suppress CVE-2026-39883 and CVE-2026-39882 for Java `io.opentelemetry` packages
- Both CVEs are for the **Go** `opentelemetry-go` SDK, not the Java OpenTelemetry libraries
  - CVE-2026-39883: PATH hijacking of `kenv` command on BSD platforms (Go-specific)
  - CVE-2026-39882: Unbounded HTTP response body reading in Go OTLP exporters
- Suppressions scoped to `pkg:maven/io.opentelemetry/opentelemetry-*` with 2-week expiry (2026-04-30)

- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1044

## Test plan
- [ ] Verify `dependencyCheckAggregate` no longer flags these CVEs for `rewrite` and `rewrite-migrate-kotlin-moderneinc`
- [ ] Confirm suppressions expire after 2 weeks