### PR TITLE
Revert Java 25 toolchain back to Java 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 21
       - uses: gradle/actions/setup-gradle@v5
       - name: build
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 21
 
       - uses: gradle/actions/setup-gradle@v5
       - name: publish-candidate

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out/
 !*/src/**/build
 .gradle/
 .idea/
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ out/
 !*/src/**/build
 .gradle/
 .idea/
-.claude/settings.local.json

--- a/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
@@ -58,7 +58,7 @@ public class RewriteJavaPlugin implements Plugin<Project> {
         });
 
         project.getExtensions().configure(JavaPluginExtension.class, java ->
-                java.toolchain(toolchain -> toolchain.getLanguageVersion().set(JavaLanguageVersion.of(25))));
+                java.toolchain(toolchain -> toolchain.getLanguageVersion().set(JavaLanguageVersion.of(21))));
 
         project.getConfigurations().all(config -> config.resolutionStrategy(strategy ->
                 strategy.cacheDynamicVersionsFor(0, "seconds")));


### PR DESCRIPTION
- Reverts #154 to restore the Java 21 toolchain. CI, publish workflow, and `RewriteJavaPlugin` are reset to `java-version: 21` / `JavaLanguageVersion.of(21)`.

We were seeing problems downstream summarized here:
- https://github.com/openrewrite/rewrite/pull/7537