### PR TITLE
Suppress CVE-2026-42154 (false positive: io.prometheus:simpleclient*)

### DIFF
--- a/src/main/resources/suppressions.xml
+++ b/src/main/resources/suppressions.xml
@@ -74,4 +74,15 @@
         <packageUrl regex="true">^pkg:maven/io\.opentelemetry/opentelemetry-.*@.*$</packageUrl>
         <cve>CVE-2026-39882</cve>
     </suppress>
+    <suppress until="2026-06-01Z">
+        <notes><![CDATA[
+            False positive. CVE-2026-42154 is for the Go Prometheus server's remote read
+            endpoint (/api/v1/read) memory-allocation DoS. The Java io.prometheus:simpleclient*
+            instrumentation libraries are unaffected — they are a separate codebase used by
+            applications to expose metrics, not the Prometheus server itself.
+            Added: 2026-05-13
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient.*@.*$</packageUrl>
+        <cve>CVE-2026-42154</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Summary

Adds an OWASP suppression for **CVE-2026-42154** ([GHSA-8rm2-7qqf-34qm](https://github.com/prometheus/prometheus/security/advisories/GHSA-8rm2-7qqf-34qm), HIGH).

The CVE is a memory-allocation DoS in the Go Prometheus server's `/api/v1/read` remote read endpoint (`github.com/prometheus/prometheus < 0.311.3`). The Java `io.prometheus:simpleclient*` instrumentation libraries (`simpleclient`, `simpleclient_tracer_common`, `simpleclient_tracer_otel`, `simpleclient_tracer_otel_agent`) are a separate codebase used by applications to expose metrics — they have no remote read endpoint and are not affected. CPE name match only.

Detected via `rewrite-micrometer`, which has `compileOnly("io.prometheus:simpleclient:latest.release")` for recipe pattern matching.

Suppression expires `2026-06-01Z` (aligns with monthly cleanup convention).

**Note:** A patch release of this plugin is required for downstream repos to pick up the suppression.

- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1069

## Test plan

- [x] `xmllint --noout src/main/resources/suppressions.xml` passes