### PR TITLE
Disambiguate Property.set(null) calls to fix Gradle 9 compilation

### DIFF
--- a/src/main/java/org/openrewrite/gradle/RewriteJava8TextBlocksPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteJava8TextBlocksPlugin.java
@@ -39,7 +39,7 @@ public class RewriteJava8TextBlocksPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getTasks().withType(JavaCompile.class).configureEach(task -> {
-            task.getOptions().getRelease().set(null);
+            task.getOptions().getRelease().set((Integer) null);
             task.doLast(new MarkClassfileWithLanguageLevel8DoLast(project.fileTree(task.getDestinationDirectory(), tree -> tree.include("**/*.class"))));
         });
     }

--- a/src/main/java/org/openrewrite/gradle/RewriteShadowPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteShadowPlugin.java
@@ -36,7 +36,7 @@ public class RewriteShadowPlugin implements Plugin<Project> {
 
         project.getTasks().withType(ShadowJar.class).configureEach(task -> {
             task.getConfigurations().set(singletonList(project.getConfigurations().getByName("compileClasspath")));
-            task.getArchiveClassifier().set(null);
+            task.getArchiveClassifier().set((String) null);
         });
     }
 }


### PR DESCRIPTION
## Summary
Fixes CI on `main` ([failing run](https://github.com/openrewrite/rewrite-build-gradle-plugin/actions/runs/25959633786/job/76312634188)). Gradle 9 makes `Property#set(null)` ambiguous between `set(T)` and `set(Provider<? extends T>)`. Casts `null` to the property's value type in `RewriteJava8TextBlocksPlugin` and `RewriteShadowPlugin` to pick the `T` overload.

## Test plan
- [x] `./gradlew compileJava` passes locally