### PR TITLE
Address dependency vulnerabilities from report #1073

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -257,6 +257,12 @@ dependencies {
         implementation("org.apache.httpcomponents.client5:httpclient5-cache:5.6.1") {
             because("CVE-2026-40542")
         }
+        implementation("org.apache.logging.log4j:log4j-api:2.25.4") {
+            because("CVE-2026-34477, CVE-2026-34479")
+        }
+        implementation("org.apache.logging.log4j:log4j-core:2.25.4") {
+            because("CVE-2026-34478, CVE-2026-34479, CVE-2026-34480, CVE-2025-68161, CVE-2026-34477")
+        }
     }
 }
 

--- a/src/main/resources/suppressions.xml
+++ b/src/main/resources/suppressions.xml
@@ -85,4 +85,43 @@
         <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient.*@.*$</packageUrl>
         <cve>CVE-2026-42154</cve>
     </suppress>
+    <suppress until="2026-07-01Z">
+        <notes><![CDATA[
+            False positive. CVE-2026-34070 is for Python langchain-core (path traversal in
+            legacy load_prompt functions). The Java dev.langchain4j library is a separate
+            project and is not affected.
+            Added: 2026-05-20
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/dev\.langchain4j/langchain4j.*@.*$</packageUrl>
+        <cve>CVE-2026-34070</cve>
+    </suppress>
+    <suppress until="2026-07-01Z">
+        <notes><![CDATA[
+            False positive. CVE-2026-41488 is for Python langchain-openai (SSRF via DNS
+            rebinding in image token counting). The Java dev.langchain4j library is a separate
+            project and is not affected. The actual severity for the Python package is LOW.
+            Added: 2026-05-20
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/dev\.langchain4j/langchain4j.*@.*$</packageUrl>
+        <cve>CVE-2026-41488</cve>
+    </suppress>
+    <suppress until="2026-08-01Z">
+        <notes><![CDATA[
+            False positive. CVE-2020-29582 was fixed in Kotlin 1.4.21. Versions 1.6.10+
+            and 1.9.10+ are not affected. The scanner incorrectly matches the CVE against
+            newer Kotlin stdlib versions.
+            Added: 2026-05-20
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-(stdlib|reflect).*@.*$</packageUrl>
+        <cve>CVE-2020-29582</cve>
+    </suppress>
+    <suppress until="2026-08-01Z">
+        <notes><![CDATA[
+            jackson-core DoS via number length constraint bypass in async parser. Transitive
+            dependency in recipe modules. Patch available in 2.18.6+.
+            Added: 2026-05-20
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-core@.*$</packageUrl>
+        <vulnerabilityName>GHSA-72hv-8253-57qq</vulnerabilityName>
+    </suppress>
 </suppressions>

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -19,4 +19,18 @@
         <packageUrl regex="true">^pkg:maven/com\.h2database/h2@2\..*$</packageUrl>
         <cve>CVE-2018-14335</cve>
     </suppress>
+    <suppress until="2026-07-01Z">
+        <notes><![CDATA[
+            False positive. These CVEs affect spring-webflux and/or spring-webmvc, not spring-core.
+            The build plugin only depends on spring-core. The scanner incorrectly matches via the
+            shared Spring Framework CPE.
+            Added: 2026-05-20
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring-(core|jcl)@.*$</packageUrl>
+        <cve>CVE-2026-22740</cve>
+        <cve>CVE-2026-22737</cve>
+        <cve>CVE-2026-22745</cve>
+        <cve>CVE-2026-22741</cve>
+        <cve>CVE-2026-22735</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Summary
- Constrain `log4j-api` and `log4j-core` to 2.25.4 to fix CVE-2026-34478, CVE-2026-34479, CVE-2026-34480, CVE-2025-68161, CVE-2026-34477 (MEDIUM, transitive from dependency-check plugin)
- Suppress `spring-core`/`spring-jcl` CVE-2026-22740, CVE-2026-22737, CVE-2026-22745, CVE-2026-22741, CVE-2026-22735 — CPE false positives (CVEs affect spring-webflux/webmvc, not spring-core)
- Suppress `langchain4j` CVE-2026-34070, CVE-2026-41488 — CPE false positives (CVEs are for Python langchain-core/langchain-openai, not Java langchain4j)
- Suppress `kotlin-stdlib`/`kotlin-reflect` CVE-2020-29582 — false positive (fixed in Kotlin 1.4.21; versions 1.6.10+ and 1.9.10+ are not affected)
- Suppress `jackson-core` GHSA-72hv-8253-57qq — MEDIUM DoS via async parser, patch available in 2.18.6+

- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1073

## Test plan
- [ ] CI passes
- [ ] `xmllint --noout suppressions.xml` validates
- [ ] `xmllint --noout src/main/resources/suppressions.xml` validates
- [ ] After patch release, downstream repos pick up shared suppressions