### PR TITLE
Pick JUnit BOM based on toolchain language version

### DIFF
--- a/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
@@ -137,6 +137,17 @@ public class RewriteJavaPlugin implements Plugin<Project> {
                                     "org.junit:junit-bom:" + pickBomVersion(toolchainVersion(project)))));
                 }));
 
+        // The dev snapshot repo (added by RewriteDependencyRepositoriesPlugin when not releasing)
+        // would otherwise let `5.+`/`6.+` resolve to JUnit -SNAPSHOT builds. Reject those so the
+        // selector falls through to the highest released version.
+        project.getConfigurations().configureEach(config ->
+                config.getResolutionStrategy().getComponentSelection().withModule(
+                        "org.junit:junit-bom", selection -> {
+                            if (selection.getCandidate().getVersion().endsWith("-SNAPSHOT")) {
+                                selection.reject("snapshot versions not allowed");
+                            }
+                        }));
+
 //        project.getTasks().withType(Test.class).configureEach(task ->
 //                project.getExtensions().configure(TestRetryTaskExtension.class, ext ->
 //                        ext.getMaxFailures().set(4))

--- a/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
@@ -70,7 +70,6 @@ public class RewriteJavaPlugin implements Plugin<Project> {
                 strategy.cacheDynamicVersionsFor(0, "seconds")));
 
         addDependencies(project, ext);
-        configureJUnitBom(project);
         configureJavaCompile(project);
         configureTesting(project);
 
@@ -105,20 +104,6 @@ public class RewriteJavaPlugin implements Plugin<Project> {
         deps.add("testImplementation", "org.assertj:assertj-core:latest.release");
     }
 
-    private static void configureJUnitBom(Project project) {
-        // Inject the JUnit BOM into every JvmTestSuite (default `test` plus any registered later).
-        // The dependency is registered eagerly via addProvider; the version lambda runs lazily,
-        // so build-script toolchain overrides (e.g. rewrite-java-8 pinning to 8) have applied
-        // by the time we pick a BOM line — no afterEvaluate required.
-        project.getExtensions().configure(TestingExtension.class, testing ->
-                testing.getSuites().withType(JvmTestSuite.class).configureEach(suite -> {
-                    String implName = suite.getSources().getImplementationConfigurationName();
-                    project.getDependencies().addProvider(implName,
-                            project.provider(() -> project.getDependencies().platform(
-                                    "org.junit:junit-bom:" + pickBomVersion(toolchainVersion(project)))));
-                }));
-    }
-
     private static String pickBomVersion(int targetJvm) {
         return targetJvm >= JUNIT_BOM_THRESHOLD ? JUNIT6_BOM_VERSION : JUNIT5_BOM_VERSION;
     }
@@ -140,6 +125,18 @@ public class RewriteJavaPlugin implements Plugin<Project> {
     }
 
     private static void configureTesting(Project project) {
+        // Inject the JUnit BOM into every JvmTestSuite (default `test` plus any registered later).
+        // The dependency is registered eagerly via addProvider; the version lambda runs lazily,
+        // so build-script toolchain overrides (e.g. rewrite-java-8 pinning to 8) have applied
+        // by the time we pick a BOM line — no afterEvaluate required.
+        project.getExtensions().configure(TestingExtension.class, testing ->
+                testing.getSuites().withType(JvmTestSuite.class).configureEach(suite -> {
+                    String implName = suite.getSources().getImplementationConfigurationName();
+                    project.getDependencies().addProvider(implName,
+                            project.provider(() -> project.getDependencies().platform(
+                                    "org.junit:junit-bom:" + pickBomVersion(toolchainVersion(project)))));
+                }));
+
 //        project.getTasks().withType(Test.class).configureEach(task ->
 //                project.getExtensions().configure(TestRetryTaskExtension.class, ext ->
 //                        ext.getMaxFailures().set(4))

--- a/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
@@ -22,6 +22,7 @@ import org.gradle.api.attributes.Attribute;
 import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.plugins.jvm.JvmTestSuite;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.testing.Test;
@@ -30,6 +31,7 @@ import org.gradle.api.tasks.testing.logging.TestLoggingContainer;
 import org.gradle.external.javadoc.CoreJavadocOptions;
 import org.gradle.jvm.tasks.Jar;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
+import org.gradle.testing.base.TestingExtension;
 
 import java.util.concurrent.TimeUnit;
 
@@ -37,6 +39,10 @@ public class RewriteJavaPlugin implements Plugin<Project> {
 
     private static final Attribute<String> CONFIGURATION_ORIGIN_ATTRIBUTE =
             Attribute.of("org.openrewrite.configuration.origin", String.class);
+
+    private static final int JUNIT_BOM_THRESHOLD = 17;
+    private static final String JUNIT5_BOM_VERSION = "5.+";
+    private static final String JUNIT6_BOM_VERSION = "6.+";
 
     @Override
     public void apply(Project project) {
@@ -64,6 +70,7 @@ public class RewriteJavaPlugin implements Plugin<Project> {
                 strategy.cacheDynamicVersionsFor(0, "seconds")));
 
         addDependencies(project, ext);
+        configureJUnitBom(project);
         configureJavaCompile(project);
         configureTesting(project);
 
@@ -90,13 +97,36 @@ public class RewriteJavaPlugin implements Plugin<Project> {
         deps.add("implementation", "org.jetbrains:annotations:latest.release");
         deps.add("compileOnly", "com.google.code.findbugs:jsr305:latest.release");
 
-        deps.add("testImplementation", deps.platform("org.junit:junit-bom:5.14.0"));
         deps.add("testImplementation", "org.junit.jupiter:junit-jupiter-api");
         deps.add("testImplementation", "org.junit.jupiter:junit-jupiter-params");
         deps.add("testRuntimeOnly", "org.junit.jupiter:junit-jupiter-engine");
         deps.add("testRuntimeOnly", "org.junit.platform:junit-platform-launcher");
 
         deps.add("testImplementation", "org.assertj:assertj-core:latest.release");
+    }
+
+    private static void configureJUnitBom(Project project) {
+        // Inject the JUnit BOM into every JvmTestSuite (default `test` plus any registered later).
+        // The dependency is registered eagerly via addProvider; the version lambda runs lazily,
+        // so build-script toolchain overrides (e.g. rewrite-java-8 pinning to 8) have applied
+        // by the time we pick a BOM line — no afterEvaluate required.
+        project.getExtensions().configure(TestingExtension.class, testing ->
+                testing.getSuites().withType(JvmTestSuite.class).configureEach(suite -> {
+                    String implName = suite.getSources().getImplementationConfigurationName();
+                    project.getDependencies().addProvider(implName,
+                            project.provider(() -> project.getDependencies().platform(
+                                    "org.junit:junit-bom:" + pickBomVersion(toolchainVersion(project)))));
+                }));
+    }
+
+    private static String pickBomVersion(int targetJvm) {
+        return targetJvm >= JUNIT_BOM_THRESHOLD ? JUNIT6_BOM_VERSION : JUNIT5_BOM_VERSION;
+    }
+
+    private static int toolchainVersion(Project project) {
+        JavaLanguageVersion v = project.getExtensions().getByType(JavaPluginExtension.class)
+                .getToolchain().getLanguageVersion().getOrNull();
+        return v != null ? v.asInt() : Runtime.version().feature();
     }
 
     private static void configureJavaCompile(Project project) {

--- a/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
@@ -104,16 +104,6 @@ public class RewriteJavaPlugin implements Plugin<Project> {
         deps.add("testImplementation", "org.assertj:assertj-core:latest.release");
     }
 
-    private static String pickBomVersion(int targetJvm) {
-        return targetJvm >= JUNIT_BOM_THRESHOLD ? JUNIT6_BOM_VERSION : JUNIT5_BOM_VERSION;
-    }
-
-    private static int toolchainVersion(Project project) {
-        JavaLanguageVersion v = project.getExtensions().getByType(JavaPluginExtension.class)
-                .getToolchain().getLanguageVersion().getOrNull();
-        return v != null ? v.asInt() : Runtime.version().feature();
-    }
-
     private static void configureJavaCompile(Project project) {
         project.getTasks().named("compileJava", JavaCompile.class, task -> task.getOptions().getRelease().set(8));
 
@@ -122,6 +112,13 @@ public class RewriteJavaPlugin implements Plugin<Project> {
             task.getOptions().getCompilerArgs().add("-parameters");
             task.getOptions().setFork(true);
         });
+    }
+
+    private static String pickBomVersion(Project project) {
+        JavaLanguageVersion v = project.getExtensions().getByType(JavaPluginExtension.class)
+                .getToolchain().getLanguageVersion().getOrNull();
+        int targetJvm = v != null ? v.asInt() : Runtime.version().feature();
+        return targetJvm >= JUNIT_BOM_THRESHOLD ? JUNIT6_BOM_VERSION : JUNIT5_BOM_VERSION;
     }
 
     private static void configureTesting(Project project) {
@@ -134,7 +131,7 @@ public class RewriteJavaPlugin implements Plugin<Project> {
                     String implName = suite.getSources().getImplementationConfigurationName();
                     project.getDependencies().addProvider(implName,
                             project.provider(() -> project.getDependencies().platform(
-                                    "org.junit:junit-bom:" + pickBomVersion(toolchainVersion(project)))));
+                                    "org.junit:junit-bom:" + pickBomVersion(project))));
                 }));
 
         // The dev snapshot repo (added by RewriteDependencyRepositoriesPlugin when not releasing)

--- a/src/test/java/org/openrewrite/gradle/RewriteJavaPluginTest.java
+++ b/src/test/java/org/openrewrite/gradle/RewriteJavaPluginTest.java
@@ -60,4 +60,43 @@ class RewriteJavaPluginTest {
 
         assertThat(requireNonNull(result.task(":test")).getOutcome()).isEqualTo(NO_SOURCE);
     }
+
+    @Test
+    void defaultToolchainSelectsJunit6Bom() throws Exception {
+        Files.writeString(settingsFile.toPath(), "rootProject.name = 'default-toolchain'");
+        Files.writeString(buildFile.toPath(),
+                //language=gradle
+                """
+                plugins {
+                    id 'org.openrewrite.build.language-library'
+                }
+                """ + printBomTask());
+
+        assertThat(runPrintBom()).contains("JUNIT_BOM=org.junit:junit-bom:6.+");
+    }
+
+    private String runPrintBom() {
+        return GradleRunner.create()
+                .withProjectDir(testProjectDir)
+                .withArguments("printJunitBom")
+                .withPluginClasspath()
+                .build()
+                .getOutput();
+    }
+
+    private static String printBomTask() {
+        //language=gradle
+        return """
+
+                tasks.register('printJunitBom') {
+                    doLast {
+                        configurations.testCompileClasspath.allDependencies.each { d ->
+                            if (d.group == 'org.junit' && d.name == 'junit-bom') {
+                                println "JUNIT_BOM=${d.group}:${d.name}:${d.version}"
+                            }
+                        }
+                    }
+                }
+                """;
+    }
 }

--- a/src/test/java/org/openrewrite/gradle/RewriteJavaPluginTest.java
+++ b/src/test/java/org/openrewrite/gradle/RewriteJavaPluginTest.java
@@ -45,18 +45,18 @@ class RewriteJavaPluginTest {
     void retry() throws Exception {
         Files.writeString(settingsFile.toPath(), "rootProject.name = 'my-project'");
         Files.writeString(buildFile.toPath(),
-                //language=gradle
-                """
-                plugins {
-                    id 'org.openrewrite.build.language-library'
-                }
-                """);
+          //language=gradle
+          """
+            plugins {
+                id 'org.openrewrite.build.language-library'
+            }
+            """);
 
         BuildResult result = GradleRunner.create()
-                .withProjectDir(testProjectDir)
-                .withArguments("test")
-                .withPluginClasspath()
-                .build();
+          .withProjectDir(testProjectDir)
+          .withArguments("test")
+          .withPluginClasspath()
+          .build();
 
         assertThat(requireNonNull(result.task(":test")).getOutcome()).isEqualTo(NO_SOURCE);
     }
@@ -64,39 +64,30 @@ class RewriteJavaPluginTest {
     @Test
     void defaultToolchainSelectsJunit6Bom() throws Exception {
         Files.writeString(settingsFile.toPath(), "rootProject.name = 'default-toolchain'");
-        Files.writeString(buildFile.toPath(),
-                //language=gradle
-                """
-                plugins {
-                    id 'org.openrewrite.build.language-library'
-                }
-                """ + printBomTask());
-
-        assertThat(runPrintBom()).contains("JUNIT_BOM=org.junit:junit-bom:6.+");
-    }
-
-    private String runPrintBom() {
-        return GradleRunner.create()
-                .withProjectDir(testProjectDir)
-                .withArguments("printJunitBom")
-                .withPluginClasspath()
-                .build()
-                .getOutput();
-    }
-
-    private static String printBomTask() {
         //language=gradle
-        return """
+        Files.writeString(buildFile.toPath(),
+          //language=gradle
+          """
+            plugins {
+                id 'org.openrewrite.build.language-library'
+            }
 
-                tasks.register('printJunitBom') {
-                    doLast {
-                        configurations.testCompileClasspath.allDependencies.each { d ->
-                            if (d.group == 'org.junit' && d.name == 'junit-bom') {
-                                println "JUNIT_BOM=${d.group}:${d.name}:${d.version}"
-                            }
+            tasks.register('printJunitBom') {
+                doLast {
+                    configurations.testCompileClasspath.allDependencies.each { d ->
+                        if (d.group == 'org.junit' && d.name == 'junit-bom') {
+                            println "JUNIT_BOM=${d.group}:${d.name}:${d.version}"
                         }
                     }
                 }
-                """;
+            }
+            """);
+
+        assertThat(GradleRunner.create()
+          .withProjectDir(testProjectDir)
+          .withArguments("printJunitBom")
+          .withPluginClasspath()
+          .build()
+          .getOutput()).contains("JUNIT_BOM=org.junit:junit-bom:6.+");
     }
 }


### PR DESCRIPTION
## Summary
- `RewriteJavaPlugin` now injects the JUnit BOM into every `JvmTestSuite`'s implementation configuration via `dependencies.addProvider(...)`: `5.+` when the effective toolchain is Java < 17, `6.+` on Java 17+.
- The toolchain language version is read lazily inside the provider, so build-script overrides (e.g. `rewrite-java-8` pinning to 8) are honored without `afterEvaluate`, and JvmTestSuites registered after plugin application are covered via `withType(...).configureEach`.
- Verified downstream: `openrewrite/rewrite` (`:rewrite-java-8` → `5.+`, `:rewrite-test:test` green) and `openrewrite/rewrite-feature-flags` (`:test` green at JUnit 6).

## Test plan
- [x] `./gradlew build` passes locally
- [x] New `RewriteJavaPluginTest.defaultToolchainSelectsJunit6Bom` asserts default toolchain → `6.+`
- [x] Manual downstream check: `:rewrite-java-8` resolves `5.+`, `:rewrite-java-8:compatibilityTest` (late-registered JvmTestSuite) also resolves `5.+`