### PR TITLE
Detect drift between recipes.csv and live recipe metadata

### DIFF
--- a/src/main/java/org/openrewrite/gradle/RecipeMarketplaceCsvValidateCompletenessTask.java
+++ b/src/main/java/org/openrewrite/gradle/RecipeMarketplaceCsvValidateCompletenessTask.java
@@ -22,7 +22,10 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.*;
 import org.openrewrite.Validated;
 import org.openrewrite.config.Environment;
+import org.openrewrite.config.OptionDescriptor;
+import org.openrewrite.config.RecipeDescriptor;
 import org.openrewrite.marketplace.RecipeClassLoader;
+import org.openrewrite.marketplace.RecipeListing;
 import org.openrewrite.marketplace.RecipeMarketplace;
 import org.openrewrite.marketplace.RecipeMarketplaceCompletenessValidator;
 import org.openrewrite.marketplace.RecipeMarketplaceReader;
@@ -30,8 +33,10 @@ import org.openrewrite.marketplace.RecipeMarketplaceReader;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.groupingBy;
@@ -58,7 +63,7 @@ public abstract class RecipeMarketplaceCsvValidateCompletenessTask extends Defau
 
     @Override
     public String getDescription() {
-        return "Validates the completeness of recipes.csv against the recipe JAR (CSV ↔ JAR synchronization)";
+        return "Validates the completeness of recipes.csv against the recipe JAR (CSV ↔ JAR synchronization), including drift in display names and descriptions";
     }
 
     @Override
@@ -85,10 +90,13 @@ public abstract class RecipeMarketplaceCsvValidateCompletenessTask extends Defau
         getLogger().info("Against recipe JAR: {}", recipeJarPath);
 
         // Validate completeness
+        RecipeMarketplace marketplace = new RecipeMarketplaceReader().fromCsv(csvPath);
+        Environment environment = jarScanningEnvironment(recipeJarPath);
         RecipeMarketplaceCompletenessValidator validator = new RecipeMarketplaceCompletenessValidator();
-        Validated<RecipeMarketplace> validation = validator.validate(
-                new RecipeMarketplaceReader().fromCsv(csvPath),
-                jarScanningEnvironment(recipeJarPath));
+        Validated<RecipeMarketplace> validation = validator.validate(marketplace, environment);
+
+        // Detect field-level drift between CSV rows and the live recipes in the environment
+        validation = validation.and(validateNoDrift(marketplace, environment));
 
         if (validation.isInvalid()) {
             Map<String, List<Validated.Invalid<RecipeMarketplace>>> byMessage = validation.failures().stream()
@@ -110,6 +118,83 @@ public abstract class RecipeMarketplaceCsvValidateCompletenessTask extends Defau
         }
 
         getLogger().lifecycle("Recipe marketplace CSV completeness validation passed");
+    }
+
+    /**
+     * Compare each CSV row's display name and description to the live values returned by the corresponding recipe
+     * in the environment, so that silent drift between source code and {@code recipes.csv} is caught at build time.
+     * <p>
+     * Rows whose recipe name is not present in the environment are skipped here; the completeness validator
+     * already flags them.
+     */
+    private Validated<RecipeMarketplace> validateNoDrift(RecipeMarketplace marketplace, Environment env) {
+        Map<String, RecipeDescriptor> byName = new HashMap<>();
+        for (RecipeDescriptor descriptor : env.listRecipeDescriptors()) {
+            byName.put(descriptor.getName(), descriptor);
+        }
+
+        Validated<RecipeMarketplace> validation = Validated.none();
+        for (RecipeListing listing : marketplace.getAllRecipes()) {
+            RecipeDescriptor descriptor = byName.get(listing.getName());
+            if (descriptor == null) {
+                continue;
+            }
+            if (!Objects.equals(listing.getDisplayName(), descriptor.getDisplayName())) {
+                validation = validation.and(Validated.invalid(
+                        listing.getName() + ".displayName",
+                        listing.getDisplayName(),
+                        "CSV value drifted from the recipe; " +
+                                "run `./gradlew recipeCsvGenerate` to update `recipes.csv`."));
+            }
+            if (!Objects.equals(listing.getDescription(), descriptor.getDescription())) {
+                validation = validation.and(Validated.invalid(
+                        listing.getName() + ".description",
+                        listing.getDescription(),
+                        "CSV value drifted from the recipe; " +
+                                "run `./gradlew recipeCsvGenerate` to update `recipes.csv`."));
+            }
+            validation = validation.and(validateOptions(listing.getName(), listing.getOptions(), descriptor.getOptions()));
+        }
+        return validation;
+    }
+
+    /**
+     * Compare CSV-listed options to the live options on the recipe descriptor. Options are matched by name; options
+     * only present on one side are skipped (the recipe's own input validation will surface those once invoked, and
+     * including them here would conflate "drift" with "set of options changed").
+     */
+    private Validated<RecipeMarketplace> validateOptions(String recipeName,
+                                                          List<OptionDescriptor> csvOptions,
+                                                          List<OptionDescriptor> liveOptions) {
+        if (csvOptions.isEmpty() || liveOptions.isEmpty()) {
+            return Validated.none();
+        }
+        Map<String, OptionDescriptor> liveByName = new HashMap<>();
+        for (OptionDescriptor live : liveOptions) {
+            liveByName.put(live.getName(), live);
+        }
+        Validated<RecipeMarketplace> validation = Validated.none();
+        for (OptionDescriptor csv : csvOptions) {
+            OptionDescriptor live = liveByName.get(csv.getName());
+            if (live == null) {
+                continue;
+            }
+            if (!Objects.equals(csv.getDisplayName(), live.getDisplayName())) {
+                validation = validation.and(Validated.invalid(
+                        recipeName + ".options[" + csv.getName() + "].displayName",
+                        csv.getDisplayName(),
+                        "CSV value drifted from the recipe; " +
+                                "run `./gradlew recipeCsvGenerate` to update `recipes.csv`."));
+            }
+            if (!Objects.equals(csv.getDescription(), live.getDescription())) {
+                validation = validation.and(Validated.invalid(
+                        recipeName + ".options[" + csv.getName() + "].description",
+                        csv.getDescription(),
+                        "CSV value drifted from the recipe; " +
+                                "run `./gradlew recipeCsvGenerate` to update `recipes.csv`."));
+            }
+        }
+        return validation;
     }
 
     /**

--- a/src/main/java/org/openrewrite/gradle/RewriteRecipeMarketplacePlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteRecipeMarketplacePlugin.java
@@ -53,6 +53,8 @@ public class RewriteRecipeMarketplacePlugin implements Plugin<Project> {
 
         TaskProvider<RecipeMarketplaceCsvValidateCompletenessTask> recipeCsvValidateCompleteness = project.getTasks().register("recipeCsvValidateCompleteness", RecipeMarketplaceCsvValidateCompletenessTask.class,
                 task -> {
+                    // Surface cheap CSV format errors before the heavier JAR-scanning completeness/drift check.
+                    task.mustRunAfter(recipeCsvValidateContent);
                     task.getRuntimeClasspath().from(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
                     if (project.getPlugins().hasPlugin(ShadowJavaPlugin.class)) {
                         task.getRecipeJar().convention(project.getTasks().named(ShadowJavaPlugin.SHADOW_JAR_TASK_NAME, ShadowJar.class).flatMap(Jar::getArchiveFile));

--- a/src/test/java/org/openrewrite/gradle/RecipeMarketplaceCsvValidateCompletenessTaskTest.java
+++ b/src/test/java/org/openrewrite/gradle/RecipeMarketplaceCsvValidateCompletenessTaskTest.java
@@ -141,6 +141,107 @@ class RecipeMarketplaceCsvValidateCompletenessTaskTest {
     }
 
     @Test
+    void failsWhenCsvDisplayNameDriftsFromRecipe() throws Exception {
+        createSimpleRecipeProject();
+        csvFile.getParentFile().mkdirs();
+        // displayName in CSV no longer matches the recipe's displayName
+        Files.writeString(csvFile.toPath(),
+          """
+          ecosystem,packageName,name,displayName,description
+          maven,org.example:test-recipe-project,org.example.TestRecipe,Stale display name,A test recipe.
+          """);
+
+        BuildResult result = GradleRunner.create()
+          .withProjectDir(projectDir)
+          .withArguments("recipeCsvValidateCompleteness", "--info", "--stacktrace")
+          .withPluginClasspath()
+          .withDebug(true)
+          .buildAndFail();
+
+        assertThat(requireNonNull(result.task(":recipeCsvValidateCompleteness")).getOutcome()).isEqualTo(FAILED);
+        assertThat(result.getOutput())
+          .contains("CSV value drifted from the recipe")
+          .contains("recipeCsvGenerate")
+          .contains("org.example.TestRecipe.displayName");
+    }
+
+    @Test
+    void failsWhenCsvDescriptionDriftsFromRecipe() throws Exception {
+        createSimpleRecipeProject();
+        csvFile.getParentFile().mkdirs();
+        // description in CSV no longer matches the recipe's description
+        Files.writeString(csvFile.toPath(),
+          """
+          ecosystem,packageName,name,displayName,description
+          maven,org.example:test-recipe-project,org.example.TestRecipe,Test recipe,A stale description.
+          """);
+
+        BuildResult result = GradleRunner.create()
+          .withProjectDir(projectDir)
+          .withArguments("recipeCsvValidateCompleteness", "--info", "--stacktrace")
+          .withPluginClasspath()
+          .withDebug(true)
+          .buildAndFail();
+
+        assertThat(requireNonNull(result.task(":recipeCsvValidateCompleteness")).getOutcome()).isEqualTo(FAILED);
+        assertThat(result.getOutput())
+          .contains("CSV value drifted from the recipe")
+          .contains("recipeCsvGenerate")
+          .contains("org.example.TestRecipe.description");
+    }
+
+    @Test
+    void failsWhenCsvOptionDisplayNameDriftsFromRecipe() throws Exception {
+        createProjectWithOptionRecipe();
+        csvFile.getParentFile().mkdirs();
+        // The Java recipe defines an option with displayName "Live option display" and
+        // description "Live option description."; the CSV's option JSON has a stale displayName.
+        Files.writeString(csvFile.toPath(),
+          """
+          ecosystem,packageName,name,displayName,description,options
+          maven,org.example:test-recipe-project,org.example.RecipeWithOption,Recipe with option,A recipe that has an option.,"[{""name"":""someOption"",""type"":""String"",""displayName"":""Stale option display"",""description"":""Live option description."",""required"":true}]"
+          """);
+
+        BuildResult result = GradleRunner.create()
+          .withProjectDir(projectDir)
+          .withArguments("recipeCsvValidateCompleteness", "--info", "--stacktrace")
+          .withPluginClasspath()
+          .withDebug(true)
+          .buildAndFail();
+
+        assertThat(requireNonNull(result.task(":recipeCsvValidateCompleteness")).getOutcome()).isEqualTo(FAILED);
+        assertThat(result.getOutput())
+          .contains("CSV value drifted from the recipe")
+          .contains("recipeCsvGenerate")
+          .contains("org.example.RecipeWithOption.options[someOption].displayName");
+    }
+
+    @Test
+    void failsWhenCsvOptionDescriptionDriftsFromRecipe() throws Exception {
+        createProjectWithOptionRecipe();
+        csvFile.getParentFile().mkdirs();
+        // CSV's option JSON has a stale description.
+        Files.writeString(csvFile.toPath(),
+          """
+          ecosystem,packageName,name,displayName,description,options
+          maven,org.example:test-recipe-project,org.example.RecipeWithOption,Recipe with option,A recipe that has an option.,"[{""name"":""someOption"",""type"":""String"",""displayName"":""Live option display"",""description"":""Stale option description."",""required"":true}]"
+          """);
+
+        BuildResult result = GradleRunner.create()
+          .withProjectDir(projectDir)
+          .withArguments("recipeCsvValidateCompleteness", "--info", "--stacktrace")
+          .withPluginClasspath()
+          .withDebug(true)
+          .buildAndFail();
+
+        assertThat(requireNonNull(result.task(":recipeCsvValidateCompleteness")).getOutcome()).isEqualTo(FAILED);
+        assertThat(result.getOutput())
+          .contains("CSV value drifted from the recipe")
+          .contains("recipeCsvGenerate")
+          .contains("org.example.RecipeWithOption.options[someOption].description");
+    }
+
+    @Test
     void skipsValidationWhenCsvDoesNotExist() throws Exception {
         createSimpleRecipeProject();
 
@@ -227,6 +328,66 @@ class RecipeMarketplaceCsvValidateCompletenessTaskTest {
     private void createProjectWithTwoRecipes() throws IOException {
         createSimpleRecipeProject();
         createRecipeClass("AnotherRecipe", "Another recipe", "Another test recipe.");
+    }
+
+    /**
+     * Create a project containing a Java recipe class with a single {@link org.openrewrite.Option}, so that option
+     * displayName / description drift between {@code recipes.csv} and the live recipe can be exercised.
+     */
+    private void createProjectWithOptionRecipe() throws IOException {
+        Files.writeString(settingsFile.toPath(), "rootProject.name = 'test-recipe-project'");
+        Files.writeString(buildFile.toPath(), """
+          plugins {
+              id 'java'
+              id 'org.openrewrite.build.recipe-library-base'
+              id 'org.openrewrite.build.publish'
+          }
+
+          group = 'org.example'
+          version = '1.0.0'
+
+          repositories {
+              mavenCentral()
+          }
+
+          dependencies {
+              implementation 'org.openrewrite:rewrite-core:latest.integration'
+          }
+          """);
+
+        File javaDir = new File(projectDir, "src/main/java/org/example");
+        javaDir.mkdirs();
+        @Language("java")
+        String recipeSource = """
+          package org.example;
+
+          import org.openrewrite.Option;
+          import org.openrewrite.Recipe;
+
+          public class RecipeWithOption extends Recipe {
+              @Option(displayName = "Live option display", description = "Live option description.")
+              private final String someOption;
+
+              public RecipeWithOption(String someOption) {
+                  this.someOption = someOption;
+              }
+
+              public String getSomeOption() {
+                  return someOption;
+              }
+
+              @Override
+              public String getDisplayName() {
+                  return "Recipe with option";
+              }
+
+              @Override
+              public String getDescription() {
+                  return "A recipe that has an option.";
+              }
+          }
+          """;
+        Files.writeString(new File(javaDir, "RecipeWithOption.java").toPath(), recipeSource);
     }
 
     private void createRecipeClass(String className, String displayName, String description) throws IOException {


### PR DESCRIPTION
## Summary

- Resolves #176: `recipeCsvValidateCompleteness` now compares each CSV row's `displayName` / `description` (and per-option `displayName` / `description`) against the live `RecipeDescriptor` from the JAR-scanning `Environment`. On mismatch the task fails and points the user at `./gradlew recipeCsvGenerate`.

- Extends `RecipeMarketplaceCsvValidateCompletenessTask` with field-level drift detection in addition to the existing ID-level completeness check. Property keys look like `org.example.Foo.displayName` and `org.example.Foo.options[someOption].description`, so the existing grouped-by-message output stays readable.
- Sibling tasks now have a deterministic order: `recipeCsvValidateContent` runs before `recipeCsvValidateCompleteness` via `mustRunAfter`. This surfaces cheap CSV format errors before paying for JAR scanning, and prevents the composite task's failure ordering from being flaky in tests.
- Adds tests covering recipe `displayName` drift, recipe `description` drift, option `displayName` drift, and option `description` drift. The option-level tests use a small Java recipe fixture (the existing YAML-only fixtures can't declare `@Option`).

## A question for the reviewer

@TimTeBeek — I went all the way down to option `displayName` / `description` because, as it stands, *new* options (or removed options) on a recipe still wouldn't be caught: I deliberately skipped options that exist only on one side, since the recipe's own input validation surfaces those when the recipe runs, and conflating "drift" with "option set changed" would muddy the error message. But you could argue that an option set that's silently fallen out of sync with the CSV is the same problem as drift — same root cause, same fix (`recipeCsvGenerate`). Do you think we should be stricter and also fail when the *set* of option names diverges? Same question for data tables (issue mentions a `DependencyInsight` `instanceName` drift example, which is currently out of scope here).

## Test plan

- [x] `./gradlew test --tests "*RecipeMarketplaceCsv*"` — 33 tests pass, including the four new drift tests.
- [x] `./gradlew test` — full suite green.
- [ ] Manual sanity check against the `rewrite-python` reproduction from the issue: with this plugin published locally, `:rewrite-python:recipeCsvValidateCompleteness` should fail for the five `AddDependency` / `ChangeDependency` / `RemoveDependency` / `UpgradeDependencyVersion` / `UpgradeTransitiveDependencyVersion` descriptions and pass again after `recipeCsvGenerate`.