### PR TITLE
Suppress OpenTelemetry CPE false positives on simpleclient_tracer_otel_agent

### DIFF
--- a/src/main/resources/suppressions.xml
+++ b/src/main/resources/suppressions.xml
@@ -124,4 +124,22 @@
         <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-core@.*$</packageUrl>
         <vulnerabilityName>GHSA-72hv-8253-57qq</vulnerabilityName>
     </suppress>
+    <suppress until="2026-07-01Z">
+        <notes><![CDATA[
+            False positive. These CVEs are for OpenTelemetry libraries (Python contrib,
+            opentelemetry-go, opentelemetry-go-contrib, opentelemetry-dotnet). The
+            io.prometheus:simpleclient_tracer_otel_agent Java jar is part of the Prometheus
+            simpleclient_tracer family — a small adapter that reads the current OpenTelemetry
+            trace context for Prometheus exemplars. It does not embed or use the affected
+            OTel SDKs. The scanner matches via the "OpenTelemetry Agent" evidence/CPE.
+            Added: 2026-05-27
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.prometheus/simpleclient_tracer_otel_agent@.*$</packageUrl>
+        <cve>CVE-2023-43810</cve>
+        <cve>CVE-2023-45142</cve>
+        <cve>CVE-2023-47108</cve>
+        <cve>CVE-2026-41078</cve>
+        <cve>CVE-2026-39882</cve>
+        <cve>CVE-2026-40894</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
## Summary

Adds an OWASP DC suppression for the OpenTelemetry-family CVEs flagged against `io.prometheus:simpleclient_tracer_otel_agent` in the shared `suppressions.xml`.

The flagged CVEs are all OpenTelemetry library vulnerabilities (Python contrib, opentelemetry-go, opentelemetry-go-contrib, opentelemetry-dotnet). The Java `io.prometheus:simpleclient_tracer_otel_agent` jar is a separate Prometheus `simpleclient_tracer` adapter that reads the current OTel trace context to attach exemplars; it does not embed or use the affected OTel SDKs. The scanner matches via the "OpenTelemetry Agent" evidence/CPE.

| CVE | Real-world affected package |
| --- | --- |
| CVE-2023-43810 | opentelemetry-instrumentation (Python) |
| CVE-2023-45142 | opentelemetry-go |
| CVE-2023-47108 | opentelemetry-go-contrib |
| CVE-2026-41078 | opentelemetry-dotnet |
| CVE-2026-39882 | opentelemetry-go |
| CVE-2026-40894 | opentelemetry-dotnet |

Expiry: `2026-07-01Z` per the 2-week-on-1st-of-month suppression policy.

Note: a patch release of this plugin is required for downstream recipe modules (e.g. `rewrite-micrometer`) to pick up the suppression.

- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1080