### PR TITLE
Annotate custom tasks with @DisableCachingByDefault for Gradle 9.5.1

### DIFF
--- a/src/main/java/org/openrewrite/gradle/RecipeDependenciesDownloadTask.java
+++ b/src/main/java/org/openrewrite/gradle/RecipeDependenciesDownloadTask.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
+@DisableCachingByDefault(because = "Resolves and downloads recipe dependencies from remote repositories")
 public class RecipeDependenciesDownloadTask extends DefaultTask {
 
     private static final ChainVersionMatcher versionMatcher = new ChainVersionMatcher();

--- a/src/main/java/org/openrewrite/gradle/RecipeDependenciesTypeTableTask.java
+++ b/src/main/java/org/openrewrite/gradle/RecipeDependenciesTypeTableTask.java
@@ -27,6 +27,7 @@ import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
 import org.openrewrite.java.internal.parser.TypeTable;
 
 import java.io.File;
@@ -37,6 +38,7 @@ import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
+@DisableCachingByDefault(because = "Resolves and downloads recipe dependencies from remote repositories")
 public abstract class RecipeDependenciesTypeTableTask extends DefaultTask {
 
     /**

--- a/src/main/java/org/openrewrite/gradle/RecipeMarketplaceCsvGenerateTask.java
+++ b/src/main/java/org/openrewrite/gradle/RecipeMarketplaceCsvGenerateTask.java
@@ -21,6 +21,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.*;
+import org.gradle.work.DisableCachingByDefault;
 import org.openrewrite.marketplace.RecipeMarketplace;
 import org.openrewrite.marketplace.RecipeMarketplaceReader;
 import org.openrewrite.marketplace.RecipeMarketplaceWriter;
@@ -35,6 +36,7 @@ import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 
+@DisableCachingByDefault(because = "Generates the recipe marketplace CSV from resolved recipe metadata")
 public abstract class RecipeMarketplaceCsvGenerateTask extends DefaultTask {
 
     @Input

--- a/src/main/java/org/openrewrite/gradle/RecipeMarketplaceCsvValidateCompletenessTask.java
+++ b/src/main/java/org/openrewrite/gradle/RecipeMarketplaceCsvValidateCompletenessTask.java
@@ -20,6 +20,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.*;
+import org.gradle.work.DisableCachingByDefault;
 import org.openrewrite.Validated;
 import org.openrewrite.config.Environment;
 import org.openrewrite.marketplace.RecipeClassLoader;
@@ -37,6 +38,7 @@ import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 
+@DisableCachingByDefault(because = "Validation task that loads recipes to verify marketplace CSV completeness")
 public abstract class RecipeMarketplaceCsvValidateCompletenessTask extends DefaultTask {
 
     /**

--- a/src/main/java/org/openrewrite/gradle/RecipeMarketplaceCsvValidateContentTask.java
+++ b/src/main/java/org/openrewrite/gradle/RecipeMarketplaceCsvValidateContentTask.java
@@ -20,6 +20,7 @@ import org.gradle.api.GradleException;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.work.DisableCachingByDefault;
 import org.openrewrite.Validated;
 import org.openrewrite.marketplace.RecipeMarketplace;
 import org.openrewrite.marketplace.RecipeMarketplaceContentValidator;
@@ -29,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+@DisableCachingByDefault(because = "Validation task that checks recipe marketplace CSV content")
 public abstract class RecipeMarketplaceCsvValidateContentTask extends DefaultTask {
 
     /**


### PR DESCRIPTION
## Problem

The `main` CI build is failing on the `:validatePlugins` task after the [Gradle 9.5.1 wrapper upgrade](https://github.com/openrewrite/rewrite-build-gradle-plugin/commit/0a245e9):

> Plugin validation failed with 5 problems:
> - Error: Type 'org.openrewrite.gradle.RecipeDependenciesDownloadTask' must be annotated either with @CacheableTask or with @DisableCachingByDefault.
> - ... (4 more)

Gradle 9 enforces that every custom task type explicitly declares its cacheability.

## Fix

Annotate the five affected task types with `@DisableCachingByDefault(because = ...)`, documenting why each is not cacheable:

- `RecipeDependenciesDownloadTask`
- `RecipeDependenciesTypeTableTask`
- `RecipeMarketplaceCsvGenerateTask`
- `RecipeMarketplaceCsvValidateCompletenessTask`
- `RecipeMarketplaceCsvValidateContentTask`

`./gradlew validatePlugins` passes locally.

Fixes the build failure in https://github.com/openrewrite/rewrite-build-gradle-plugin/actions/runs/26598434463/job/78375433982