### PR TITLE
Restrict maven-snapshots repository to OpenRewrite/Moderne groups

### DIFF
--- a/src/main/java/org/openrewrite/gradle/RewriteDependencyRepositoriesPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteDependencyRepositoriesPlugin.java
@@ -18,6 +18,7 @@ package org.openrewrite.gradle;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
+import org.gradle.api.artifacts.repositories.MavenRepositoryContentDescriptor;
 
 public class RewriteDependencyRepositoriesPlugin implements Plugin<Project> {
 
@@ -28,7 +29,11 @@ public class RewriteDependencyRepositoriesPlugin implements Plugin<Project> {
         if (!project.hasProperty("releasing")) {
             repos.add(repos.mavenLocal(repo -> repo.content(content ->
                     content.excludeVersionByRegex(".+", ".+", ".+-rc[-]?[0-9]*"))));
-            repos.add(repos.maven(repo -> repo.setUrl("https://central.sonatype.com/repository/maven-snapshots/")));
+            repos.add(repos.maven(repo -> {
+                repo.setUrl("https://central.sonatype.com/repository/maven-snapshots/");
+                // Only serve snapshots from here so a snapshots-repo outage can't break release resolution
+                repo.mavenContent(MavenRepositoryContentDescriptor::snapshotsOnly);
+            }));
         }
 
         repos.add(repos.mavenCentral(repo -> repo.content(content ->

--- a/src/main/java/org/openrewrite/gradle/RewriteDependencyRepositoriesPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteDependencyRepositoriesPlugin.java
@@ -18,7 +18,6 @@ package org.openrewrite.gradle;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
-import org.gradle.api.artifacts.repositories.MavenRepositoryContentDescriptor;
 
 public class RewriteDependencyRepositoriesPlugin implements Plugin<Project> {
 
@@ -31,8 +30,12 @@ public class RewriteDependencyRepositoriesPlugin implements Plugin<Project> {
                     content.excludeVersionByRegex(".+", ".+", ".+-rc[-]?[0-9]*"))));
             repos.add(repos.maven(repo -> {
                 repo.setUrl("https://central.sonatype.com/repository/maven-snapshots/");
-                // Only serve snapshots from here so a snapshots-repo outage can't break release resolution
-                repo.mavenContent(MavenRepositoryContentDescriptor::snapshotsOnly);
+                // Only consult the snapshots repo for groups that actually publish snapshots we consume,
+                // so a snapshots-repo outage can't break resolution of third-party releases.
+                repo.content(content -> {
+                    content.includeGroupAndSubgroups("org.openrewrite");
+                    content.includeGroupAndSubgroups("io.moderne");
+                });
             }));
         }
 


### PR DESCRIPTION
## Problem

The shared `RewriteDependencyRepositoriesPlugin` declares the OpenRewrite snapshots repo (`https://central.sonatype.com/repository/maven-snapshots/`) **before** Maven Central with **no content filter**. Gradle therefore queries *every* dependency against the snapshots repo first — including release artifacts.

This is a latent build-fragility bug. On `rewrite-gradle-plugin`, a `main` build failed at `:plugin:compileKotlin`: once Kotlin `2.4.0` became `latest.release`, resolving its parent BOM `kotlin-gradle-plugins-bom:2.4.0` (a **release**) was attempted against the snapshots repo, which timed out. Gradle then disabled the repo and cascade-failed the whole resolution.

Since this convention plugin is applied across ~all OpenRewrite repos, the same failure mode is latent everywhere. Fixing it centrally here.

## Fix

Add a content filter so the snapshots repo is only consulted for the groups that actually publish snapshots we consume: `org.openrewrite` and `io.moderne` (both including subgroups, e.g. `org.openrewrite.tools`, `org.openrewrite.gradle.tooling`). Every other dependency (Kotlin, Guava, JUnit, …) now resolves straight from Maven Central, so a snapshots-repo outage can no longer break resolution of third-party releases.

This is an allowlist: if a new group ever needs snapshot resolution (a transitive `*-SNAPSHOT` from another group — exactly how `io.moderne:jsonrpc` first surfaced this), add it here. `includeGroupAndSubgroups` requires Gradle 7.6+.

## Verification

- `./gradlew build` passes locally.

See the sibling inline fix openrewrite/rewrite-gradle-plugin#450 for context.