### PR TITLE
Renew expired OWASP suppressions, add langchain4j CVE-2026-44843

### DIFF
--- a/src/main/resources/suppressions.xml
+++ b/src/main/resources/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2026-06-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
        file name: rewrite-jenkins-0.22.0-SNAPSHOT.jar
        sev: HIGH
@@ -10,7 +10,7 @@
         <cve>CVE-2022-34792</cve>
         <cve>CVE-2022-34794</cve>
     </suppress>
-    <suppress until="2026-06-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
        file name: rewrite-openapi-0.6.0-SNAPSHOT.jar
            sev: HIGH
@@ -19,7 +19,7 @@
         <packageUrl regex="true">^pkg:maven/org\.openrewrite\.recipe/rewrite-openapi@.*$</packageUrl>
         <cve>CVE-2022-24863</cve>
     </suppress>
-    <suppress until="2026-06-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
    file name: rewrite-logging-frameworks-2.19.0-SNAPSHOT.jar: log4j-1.2.17.jar
     sev: CRITICAL
@@ -34,7 +34,7 @@
         <cve>CVE-2023-26464</cve>
         <cve>CVE-2021-4104</cve>
     </suppress>
-    <suppress until="2026-06-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
             file name: openai4j-0.25.0.jar
             sev: MEDIUM
@@ -45,7 +45,7 @@
         <packageUrl regex="true">^pkg:maven/dev\.ai4j/openai4j@.*$</packageUrl>
         <cve>CVE-2025-43714</cve>
     </suppress>
-    <suppress until="2026-06-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
             file name: rewrite-openapi-*.jar
             sev: MEDIUM
@@ -56,7 +56,7 @@
         <packageUrl regex="true">^pkg:maven/org\.openrewrite\.recipe/rewrite-openapi@.*$</packageUrl>
         <cve>CVE-2024-25712</cve>
     </suppress>
-    <suppress until="2026-06-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
             False positive. CVE-2026-39883 is for the Go opentelemetry-go SDK (PATH hijacking
             of the kenv command on BSD). The Java io.opentelemetry packages are unaffected.
@@ -65,7 +65,7 @@
         <packageUrl regex="true">^pkg:maven/io\.opentelemetry/opentelemetry-.*@.*$</packageUrl>
         <cve>CVE-2026-39883</cve>
     </suppress>
-    <suppress until="2026-06-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
             False positive. CVE-2026-39882 is for Go OTLP HTTP exporters (unbounded response
             body reading). The Java io.opentelemetry packages are unaffected.
@@ -74,7 +74,7 @@
         <packageUrl regex="true">^pkg:maven/io\.opentelemetry/opentelemetry-.*@.*$</packageUrl>
         <cve>CVE-2026-39882</cve>
     </suppress>
-    <suppress until="2026-06-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
             False positive. CVE-2026-42154 is for the Go Prometheus server's remote read
             endpoint (/api/v1/read) memory-allocation DoS. The Java io.prometheus:simpleclient*
@@ -105,7 +105,18 @@
         <packageUrl regex="true">^pkg:maven/dev\.langchain4j/langchain4j.*@.*$</packageUrl>
         <cve>CVE-2026-41488</cve>
     </suppress>
-    <suppress until="2026-08-01Z">
+    <suppress until="2026-07-01Z">
+        <notes><![CDATA[
+            False positive. CVE-2026-44843 (GHSA-pjwx-r37v-7724) is unsafe deserialization
+            via overly broad load() allowlists in the Python langchain-core (PIP) package.
+            The Java dev.langchain4j library is a separate project and is not affected.
+            The scanner matches on the "langchain" name.
+            Added: 2026-06-04
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/dev\.langchain4j/langchain4j.*@.*$</packageUrl>
+        <cve>CVE-2026-44843</cve>
+    </suppress>
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
             False positive. CVE-2020-29582 was fixed in Kotlin 1.4.21. Versions 1.6.10+
             and 1.9.10+ are not affected. The scanner incorrectly matches the CVE against
@@ -115,7 +126,7 @@
         <packageUrl regex="true">^pkg:maven/org\.jetbrains\.kotlin/kotlin-(stdlib|reflect).*@.*$</packageUrl>
         <cve>CVE-2020-29582</cve>
     </suppress>
-    <suppress until="2026-08-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
             jackson-core DoS via number length constraint bypass in async parser. Transitive
             dependency in recipe modules. Patch available in 2.18.6+.

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2026-06-01Z">
+    <suppress until="2026-07-01Z">
         <notes><![CDATA[
             file name: okio-jvm-2.10.0.jar
             sev: HIGH


### PR DESCRIPTION
- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1085

All false-positive suppressions with `until="2026-06-01Z"` expired on 2026-06-01 and were swept by the monthly cleanup, so they resurfaced in the 2026-06-03 OpenRewrite report. This renews them to `2026-07-01Z` and adds one new false positive.

### `src/main/resources/suppressions.xml` (shared base)
Renewed (all confirmed false positives):
- `CVE-2022-34793/2/4` — rewrite-jenkins (Jenkins plugin CVEs, not the recipe jar) — HIGH
- `CVE-2022-24863`, `CVE-2024-25712` — rewrite-openapi (Go http-swagger, not the Java lib)
- `CVE-2019-17571`, `CVE-2020-9493`, `CVE-2022-23302/5/7`, `CVE-2023-26464`, `CVE-2021-4104` — log4j 1.2.17 (reference-only) — CRITICAL
- `CVE-2025-43714` — openai4j (ChatGPT web UI XSS, not the client) — MEDIUM
- `CVE-2026-39883`, `CVE-2026-39882` — io.opentelemetry (Go SDK, not Java) — HIGH
- `CVE-2026-42154` — io.prometheus simpleclient (Go Prometheus server, not Java)

Added:
- `CVE-2026-44843` (GHSA-pjwx-r37v-7724) — unsafe deserialization in **Python** `langchain-core` (PIP). Java `dev.langchain4j` is a separate project; verified the advisory scopes only the PIP ecosystem. HIGH.

### `suppressions.xml` (plugin root)
- `CVE-2023-3635` — okio (release-plugin dep, not used at runtime where the DoS vector applies) — HIGH

⚠️ Changes to `src/main/resources/suppressions.xml` require a **patch release of the plugin** for downstream recipe modules to pick them up.