### PR TITLE
Flag BOM-bumped modules against consumers built on the old version

### DIFF
--- a/src/main/java/org/openrewrite/gradle/RewriteBomAlignmentPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteBomAlignmentPlugin.java
@@ -87,6 +87,7 @@ public class RewriteBomAlignmentPlugin implements Plugin<Project> {
                             .computeIfAbsent(bom.getValue(), k -> new LinkedHashSet<>())
                             .add(moduleId + ":" + bom.getValue() + " (via inheritsFrom)");
                 }
+                String selectedManagedRequester = project.getName() + " (selected/managed version)";
                 for (DependencyResult dep : resolutionResult.getAllDependencies()) {
                     if (!(dep instanceof ResolvedDependencyResult edge)) {
                         continue;
@@ -100,6 +101,22 @@ public class RewriteBomAlignmentPlugin implements Plugin<Project> {
                     }
                     if (!isManagedRequester(edge.getFrom().getId())) {
                         continue;
+                    }
+                    // For the BOM's own direct `api` declarations, record the version the graph actually
+                    // *selected* — attributed to the BOM itself. The BOM bumps modules via dynamic
+                    // `api("…:latest.release")` entries whose requested selector is filtered out below, so
+                    // the selected (new) version would otherwise never be recorded as a pin. Without this,
+                    // "BOM manages X@new while a concrete consumer still requests X@old" stays invisible:
+                    // only the old concrete request is seen, yielding a single version → no mismatch.
+                    // Restricting to edges *from the BOM project* avoids flagging modules a third party
+                    // merely forced upward — those aren't versions the BOM is choosing to publish.
+                    if (edge.getFrom().getId() instanceof ProjectComponentIdentifier &&
+                            edge.getSelected().getId() instanceof ModuleComponentIdentifier selectedId &&
+                            isManagedGroup(selectedId.getGroup())) {
+                        requestedVersions
+                                .computeIfAbsent(selectedId.getGroup() + ":" + selectedId.getModule(), k -> new LinkedHashMap<>())
+                                .computeIfAbsent(selectedId.getVersion(), k -> new LinkedHashSet<>())
+                                .add(selectedManagedRequester);
                     }
                     String version = selector.getVersion();
                     if (isDynamicVersion(version)) {

--- a/src/test/java/org/openrewrite/gradle/RewriteBomAlignmentPluginTest.java
+++ b/src/test/java/org/openrewrite/gradle/RewriteBomAlignmentPluginTest.java
@@ -138,6 +138,91 @@ class RewriteBomAlignmentPluginTest {
     }
 
     @Test
+    void failsWhenBomBumpsModuleNewerThanAConcreteConsumerWasBuiltAgainst() throws Exception {
+        // The BOM declares core via a dynamic `latest.release` selector that resolves to 2.0.0, while
+        // `bar` (a sibling module the BOM also publishes) was built against the older core:1.0.0. The
+        // BOM's own pin is dynamic, so its requested selector is filtered out — only bar's concrete
+        // 1.0.0 request would otherwise be seen, leaving a single version and hiding the mismatch.
+        // Recording the BOM's *selected* (2.0.0) version surfaces it.
+        publishMavenMetadata("org.openrewrite.recipe", "core", "2.0.0", "1.0.0", "2.0.0");
+
+        writeFile(settingsFile, "rootProject.name = 'bom-bumps-newer'");
+
+        //language=groovy
+        String buildFileContent = """
+                plugins {
+                    id 'java-platform'
+                    id 'org.openrewrite.build.bom-alignment'
+                }
+                javaPlatform { allowDependencies() }
+                repositories {
+                    maven { url = uri('%s') }
+                }
+                dependencies {
+                    api 'org.openrewrite.recipe:core:latest.release'
+                    api 'org.openrewrite.recipe:bar:1.0.0'
+                }
+                """.formatted(repoDir.toURI());
+
+        writeFile(buildFile, buildFileContent);
+
+        BuildResult result = GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withArguments("checkBomAlignment", "--stacktrace")
+                .withPluginClasspath()
+                .withDebug(true)
+                .buildAndFail();
+
+        assertThat(result.getOutput())
+                .contains("BOM dependency version mismatches")
+                .contains("org.openrewrite.recipe:core")
+                // 1.0.0 is what bar still requests; 2.0.0 is what the BOM selected/manages.
+                .contains("1.0.0")
+                .contains("2.0.0")
+                .contains("selected/managed version")
+                // bar is the outdated consumer needing a re-release against the new core.
+                .contains("org.openrewrite.recipe:bar")
+                .contains("requests org.openrewrite.recipe:core:1.0.0 (latest 2.0.0)");
+    }
+
+    @Test
+    void passesWhenBomBumpedModuleMatchesEveryConcreteConsumer() throws Exception {
+        // Companion negative case: the BOM again bumps core to 2.0.0 via `latest.release`, but the
+        // sibling module it ships (baz) was already built against core:2.0.0. Selected and concrete
+        // requested versions agree, so recording the selected version must stay idempotent — no mismatch.
+        publishMavenMetadata("org.openrewrite.recipe", "core", "2.0.0", "1.0.0", "2.0.0");
+
+        writeFile(settingsFile, "rootProject.name = 'bom-bumps-aligned'");
+
+        //language=groovy
+        String buildFileContent = """
+                plugins {
+                    id 'java-platform'
+                    id 'org.openrewrite.build.bom-alignment'
+                }
+                javaPlatform { allowDependencies() }
+                repositories {
+                    maven { url = uri('%s') }
+                }
+                dependencies {
+                    api 'org.openrewrite.recipe:core:latest.release'
+                    api 'org.openrewrite.recipe:baz:1.0.0'
+                }
+                """.formatted(repoDir.toURI());
+
+        writeFile(buildFile, buildFileContent);
+
+        BuildResult result = GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withArguments("checkBomAlignment", "--stacktrace")
+                .withPluginClasspath()
+                .withDebug(true)
+                .build();
+
+        assertThat(requireNonNull(result.task(":checkBomAlignment")).getOutcome()).isEqualTo(SUCCESS);
+    }
+
+    @Test
     void bomManagingStaleVersionIsFlaggedAsNeedingRelease() throws Exception {
         // A BOM that pins an older version of a managed module than what's actually being used in
         // the graph is itself out of date — its <dependencyManagement> needs refreshing.
@@ -683,6 +768,31 @@ class RewriteBomAlignmentPluginTest {
                 </project>
                 """.formatted(group, artifact, version, depsXml, extraXml);
         writeFile(new File(dir, artifact + "-" + version + ".pom"), pom);
+    }
+
+    /** Write a maven-metadata.xml so Gradle can resolve dynamic selectors (e.g. {@code latest.release}). */
+    private void publishMavenMetadata(String group, String artifact, String releaseVersion, String... versions) throws IOException {
+        File dir = new File(repoDir, group.replace('.', '/') + "/" + artifact);
+        assertThat(dir.exists() || dir.mkdirs()).isTrue();
+        StringBuilder versionsXml = new StringBuilder();
+        for (String version : versions) {
+            versionsXml.append("            <version>").append(version).append("</version>\n");
+        }
+        String metadata = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <metadata>
+                    <groupId>%s</groupId>
+                    <artifactId>%s</artifactId>
+                    <versioning>
+                        <latest>%s</latest>
+                        <release>%s</release>
+                        <versions>
+                %s        </versions>
+                        <lastUpdated>20260101000000</lastUpdated>
+                    </versioning>
+                </metadata>
+                """.formatted(group, artifact, releaseVersion, releaseVersion, versionsXml);
+        writeFile(new File(dir, "maven-metadata.xml"), metadata);
     }
 
     private void writeFile(File destination, String content) throws IOException {


### PR DESCRIPTION
`checkBomAlignment` built its mismatch view only from `edge.getRequested()` selectors, so when the BOM bumps a module via a dynamic `api("…:latest.release")` entry, that requested selector was filtered out and the module's selected (new) version was never recorded — leaving the discrepancy invisible whenever the only concrete requesters were sibling modules built against the old version. This change additionally records each module's `edge.getSelected()` version as a pin, but only for edges from the BOM project itself (attributed to a `"<project> (selected/managed version)"` requester), so a module with selected `2` and concrete-requested `1` now surfaces as a mismatch. Restricting to the BOM's own direct declarations avoids misattributing a version that a third party merely forced upward. Adds a positive and a companion negative test reproducing the scenario via a `maven-metadata.xml` helper so the dynamic `latest.release` selector resolves.