### PR TITLE
Upgrade spring-core to 6.2.19 (HIGH-severity Spring Framework DoS CVEs)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -207,7 +207,7 @@ dependencies {
         exclude(group = "org.springframework", module = "spring-asm")
     }
     // Provide a newer Spring version to replace the excluded 3.1.3
-    implementation("org.springframework:spring-core:6.2.11")
+    implementation("org.springframework:spring-core:6.2.19")
     implementation("com.github.jk1:gradle-license-report:1.16")
     implementation("org.owasp:dependency-check-gradle:latest.release") {
         exclude(group = "org.apache.lucene", module = "lucene-facet") // 9.12.3 Brings in a vulnerability


### PR DESCRIPTION
Bumps the directly-pinned `spring-core` from 6.2.11 to 6.2.19, the OSS fixed version for six HIGH-severity Spring Framework Denial-of-Service advisories. This also pulls `spring-jcl` up to 6.2.19 transitively.

CVEs (all affect Spring Framework 6.2.0–6.2.18, fixed in 6.2.19):
- [CVE-2026-41840](https://spring.io/security/cve-2026-41840)
- [CVE-2026-41841](https://spring.io/security/cve-2026-41841)
- [CVE-2026-41842](https://spring.io/security/cve-2026-41842) — DoS resolving static resources (Spring MVC/WebFlux)
- [CVE-2026-41843](https://spring.io/security/cve-2026-41843)
- [CVE-2026-41850](https://spring.io/security/cve-2026-41850) — Algorithmic DoS evaluating SpEL expressions
- [CVE-2026-41851](https://spring.io/security/cve-2026-41851)

`spring-core` is explicitly pinned here to override the old 3.1.3 excluded from the license-gradle-plugin, so this is a one-line version bump. Verified locally that `spring-core` and `spring-jcl` both resolve to 6.2.19 on the runtime classpath.

- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1087