### PR TITLE
Upgrade to Jackson 2.21.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -221,7 +221,7 @@ dependencies {
     implementation("com.gradleup.shadow:com.gradleup.shadow.gradle.plugin:9.0.0-beta7") // Latest supporting Java 8
 
     implementation("org.jspecify:jspecify:1.0.0")
-    implementation(platform("com.fasterxml.jackson:jackson-bom:2.21.2"))
+    implementation(platform("com.fasterxml.jackson:jackson-bom:2.21.4"))
     implementation("com.fasterxml.jackson.core:jackson-core")
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")

--- a/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
@@ -49,7 +49,7 @@ public class RewriteJavaPlugin implements Plugin<Project> {
         project.getPlugins().apply(RewriteDependencyCheckPlugin.class);
 
         RewriteJavaExtension ext = project.getExtensions().create("rewriteJava", RewriteJavaExtension.class);
-        ext.getJacksonVersion().convention("2.21.2");
+        ext.getJacksonVersion().convention("2.21.4");
 
         project.getPlugins().apply(JavaLibraryPlugin.class);
 


### PR DESCRIPTION
## What's changed?
Upgrade from Jackson 2.21.2 to 2.21.4

## What's your motivation?
Vulnerability remediation of:
* CVE-2026-54513
* CVE-2026-54512

## Any additional context
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.21.4