### PR TITLE
Suppress CVE-2026-50559: quarkus-update-recipes false positive

### DIFF
--- a/src/main/resources/suppressions.xml
+++ b/src/main/resources/suppressions.xml
@@ -181,4 +181,18 @@
         <vulnerabilityName>GHSA-2r2c-cx56-8933</vulnerabilityName>
         <vulnerabilityName>GHSA-47qp-hqvx-6r3f</vulnerabilityName>
     </suppress>
+    <suppress until="2026-08-01Z">
+        <notes><![CDATA[
+            False positive. CVE-2026-50559 (GHSA-qcxp-gm7m-4j5v) is an HTTP path-based
+            authorization bypass in the Quarkus runtime (io.quarkus:quarkus-vertx-http,
+            Quarkus 3.x) via encoded matrix parameters and encoded slashes. By contrast
+            io.quarkus:quarkus-update-recipes is an OpenRewrite recipe JAR (versioned 1.x)
+            that ships YAML migration recipes for Quarkus apps; it does not contain or use
+            the vulnerable quarkus-vertx-http runtime. CPE name-match on "quarkus" only.
+            Arrives transitively via rewrite-third-party (e.g. through rewrite-recipe-bom).
+            Added: 2026-07-01
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.quarkus/quarkus-update-recipes@.*$</packageUrl>
+        <cve>CVE-2026-50559</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1112

## What
Adds a shared OWASP suppression for **CVE-2026-50559** (GHSA-qcxp-gm7m-4j5v, HIGH) on `io.quarkus:quarkus-update-recipes`.

## Why — false positive
CVE-2026-50559 is an HTTP path-based authorization bypass in the **Quarkus runtime** (`io.quarkus:quarkus-vertx-http`, Quarkus 3.x) via encoded matrix parameters / encoded slashes. `io.quarkus:quarkus-update-recipes` is an OpenRewrite recipe JAR (versioned 1.x) shipping YAML migration recipes for Quarkus apps — it does **not** contain or use the vulnerable `quarkus-vertx-http` runtime. The dependency-check match is a CPE name-match on "quarkus" only.

It arrives transitively via `rewrite-third-party` (e.g. through `rewrite-recipe-bom`). The same false positive is already suppressed per-repo (rewrite-quarkus, rewrite-spring-to-quarkus) and in rewrite-third-party's own suppressions, but the scan of `rewrite-recipe-bom` and other delegating repos is not covered — hence adding it to the shared list here.

Time-boxed to 2026-08-01Z to match the batch-expiry convention in this file.

## Note
A patch release of the plugin is required for downstream repos to pick up this change.

Validated with `xmllint --noout`.