### PR TITLE
Fix CVE-2026-54399 (Apache HttpComponents Core DoS)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -257,6 +257,12 @@ dependencies {
         implementation("org.apache.httpcomponents.client5:httpclient5-cache:5.6.1") {
             because("CVE-2026-40542")
         }
+        implementation("org.apache.httpcomponents.core5:httpcore5:5.4.3") {
+            because("CVE-2026-54399")
+        }
+        implementation("org.apache.httpcomponents.core5:httpcore5-h2:5.4.3") {
+            because("CVE-2026-54399")
+        }
         implementation("org.apache.logging.log4j:log4j-api:2.25.4") {
             because("CVE-2026-34477, CVE-2026-34479")
         }

--- a/src/main/resources/suppressions.xml
+++ b/src/main/resources/suppressions.xml
@@ -260,4 +260,19 @@
         <packageUrl regex="true">^pkg:maven/org\.scala-sbt\.jline/jline@.*$</packageUrl>
         <cve>CVE-2023-50572</cve>
     </suppress>
+    <suppress until="2026-08-01Z">
+        <notes><![CDATA[
+            False positive. CVE-2026-54399 is an HTTP/1.1 message-parser memory-exhaustion
+            DoS in Apache HttpComponents Core 5.x (maven org.apache.httpcomponents.core5:httpcore5,
+            versions <= 5.4.2 and 5.5-alpha1/5.5-beta1; fixed in 5.4.3). The NVD CPE range
+            (apache:httpcomponents_core <= 5.4.2) numerically over-matches the separate 4.x
+            product line org.apache.httpcomponents:httpcore / httpcore-nio 4.4.x, which is a
+            distinct codebase Apache did not list as affected. These 4.x jars arrive
+            transitively (e.g. com.konghq:unirest-java, software.amazon.awssdk:v2-migration)
+            on recipe classpaths only and are not the vulnerable core5 artifact.
+            Added: 2026-07-06
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpcore(-nio)?@4\..*$</packageUrl>
+        <cve>CVE-2026-54399</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1121

**CVE-2026-54399** (HIGH, CVSS 7.5) — Uncontrolled Resource Consumption in the HTTP/1.1 message parser of Apache HttpComponents **Core 5.x** (`org.apache.httpcomponents.core5:httpcore5` ≤ 5.4.2 and 5.5-alpha1/5.5-beta1). Fixed upstream in **5.4.3**.

Two changes:

1. **Remediate (build.gradle.kts constraints):** force `httpcore5` / `httpcore5-h2` to `5.4.3`. These arrive transitively via `dependency-check-gradle` and `httpclient5:5.6.1` on the plugin's own build classpath. Verified with `./gradlew dependencies --configuration runtimeClasspath`: `httpcore5:5.4.2 -> 5.4.3`, `httpcore5-h2:5.4 -> 5.4.3`.

2. **Suppress the 4.x false positive (shared `src/main/resources/suppressions.xml`):** the `org.apache.httpcomponents:httpcore` / `httpcore-nio` **4.4.x** jars (pulled by `unirest-java` in rewrite-ai-search and `awssdk:v2-migration` in rewrite-third-party) are a separate product line Apache did **not** list as affected; the NVD CPE range `apache:httpcomponents_core ≤ 5.4.2` numerically over-matches them. Time-boxed to `2026-08-01Z`.

> Note: a patch release of this plugin is required for downstream recipe modules to pick up the shared-suppression change.