### PR TITLE
Bump Jackson to 2.21.5 and drop resolved jackson-databind suppressions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -221,7 +221,7 @@ dependencies {
     implementation("com.gradleup.shadow:com.gradleup.shadow.gradle.plugin:9.0.0-beta7") // Latest supporting Java 8
 
     implementation("org.jspecify:jspecify:1.0.0")
-    implementation(platform("com.fasterxml.jackson:jackson-bom:2.21.4"))
+    implementation(platform("com.fasterxml.jackson:jackson-bom:2.21.5"))
     implementation("com.fasterxml.jackson.core:jackson-core")
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")

--- a/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
+++ b/src/main/java/org/openrewrite/gradle/RewriteJavaPlugin.java
@@ -49,7 +49,7 @@ public class RewriteJavaPlugin implements Plugin<Project> {
         project.getPlugins().apply(RewriteDependencyCheckPlugin.class);
 
         RewriteJavaExtension ext = project.getExtensions().create("rewriteJava", RewriteJavaExtension.class);
-        ext.getJacksonVersion().convention("2.21.4");
+        ext.getJacksonVersion().convention("2.21.5");
 
         project.getPlugins().apply(JavaLibraryPlugin.class);
 

--- a/src/main/resources/suppressions.xml
+++ b/src/main/resources/suppressions.xml
@@ -198,28 +198,6 @@
     </suppress>
     <suppress until="2026-08-01Z">
         <notes><![CDATA[
-            jackson-databind polymorphic-typing / deserialization advisories:
-            CVE-2026-54512 (PolymorphicTypeValidator bypass via generic type parameters),
-            CVE-2026-54513 (allowIfSubTypeIsArray allowlist bypass), CVE-2026-54514
-            (InetSocketAddress eager DNS resolution / SSRF) and CVE-2026-54515
-            (case-insensitive deserialization bypasses per-property @JsonIgnoreProperties).
-            All require enabling default/polymorphic typing on attacker-controlled input;
-            OpenRewrite uses jackson to parse its own recipe YAML and serialized LSTs, not
-            untrusted polymorphic JSON, so the gadget paths are not reachable. jackson is
-            centrally managed via rewrite-core, so the version cannot be bumped per recipe
-            module. The two HIGH advisories only affect the older 2.17.x line; 2.21.4 and
-            2.22.0 are already past their patch lines. Re-evaluate when rewrite-core adopts
-            the clean 2.18.9 / 2.21.5 / 2.22.1 patch releases.
-            Added: 2026-07-03
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson-databind@.*$</packageUrl>
-        <cve>CVE-2026-54512</cve>
-        <cve>CVE-2026-54513</cve>
-        <cve>CVE-2026-54514</cve>
-        <cve>CVE-2026-54515</cve>
-    </suppress>
-    <suppress until="2026-08-01Z">
-        <notes><![CDATA[
             False positive. CVE-2023-46122 (GHSA-h9mw-grgx-2fhf, LOW) is a Zip-Slip archive
             extraction flaw in org.scala-sbt:io / org.scala-sbt:sbt < 1.9.7. The flagged
             artifacts org.scala-sbt:launcher-interface and org.scala-sbt:sbinary_2.13 are


### PR DESCRIPTION
Upgrades Jackson from 2.21.4 to 2.21.5, which includes patches for CVE-2026-54512/54513/54514/54515. The temporary suppression entries for jackson-databind are no longer needed.