### PR TITLE
Suppress CVE-2026-54428 (httpcore 4.x) and camel-upgrade-recipes CPE over-matches

### DIFF
--- a/src/main/resources/suppressions.xml
+++ b/src/main/resources/suppressions.xml
@@ -238,7 +238,7 @@
         <packageUrl regex="true">^pkg:maven/org\.scala-sbt\.jline/jline@.*$</packageUrl>
         <cve>CVE-2023-50572</cve>
     </suppress>
-    <suppress until="2026-08-01Z">
+    <suppress>
         <notes><![CDATA[
             False positive. CVE-2026-54399 is an HTTP/1.1 message-parser memory-exhaustion
             DoS in Apache HttpComponents Core 5.x (maven org.apache.httpcomponents.core5:httpcore5,
@@ -248,9 +248,41 @@
             distinct codebase Apache did not list as affected. These 4.x jars arrive
             transitively (e.g. com.konghq:unirest-java, software.amazon.awssdk:v2-migration)
             on recipe classpaths only and are not the vulnerable core5 artifact.
+            Same-vendor cross-product-line over-match, pinned to the CVE and suppressed
+            indefinitely: CVE-2026-54399 is permanently scoped to core5, so the 4.x line can
+            never become a true positive for this CVE.
             Added: 2026-07-06
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpcore(-nio)?@4\..*$</packageUrl>
         <cve>CVE-2026-54399</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            False positive. CVE-2026-54428 is an HTTP/2 HPACK-decoder memory-exhaustion DoS in
+            Apache HttpComponents Core 5.x (maven org.apache.httpcomponents.core5:httpcore5,
+            versions <= 5.4.2 and 5.5-beta1). HTTP/2 does not exist in the separate 4.x product
+            line org.apache.httpcomponents:httpcore / httpcore-nio 4.4.x, but the NVD CPE range
+            (apache:httpcomponents_core <= 5.4.2) numerically over-matches those 4.x jars, which
+            Apache did not list as affected. Same-vendor cross-product-line over-match, identical
+            to CVE-2026-54399 above; pinned to the CVE and suppressed indefinitely (permanently
+            core5-scoped, so the 4.x line can never become a true positive for this CVE).
+            Added: 2026-07-13
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpcore(-nio)?@4\..*$</packageUrl>
+        <cve>CVE-2026-54428</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+            False positive. Reference only. org.apache.camel.upgrade:camel-upgrade-recipes is the
+            OpenRewrite recipe artifact that migrates user code between Apache Camel versions — it
+            carries recipe definitions, not the Camel runtime. Its version tracks Camel releases
+            (4.20.0), so the apache:camel CPE numerically over-matches it, flooding the scan with
+            Camel runtime CVEs (camel-core, camel-pqc, etc.) that this artifact does not ship.
+            Suppress all apache:camel CPE matches against this artifact indefinitely, mirroring the
+            io.quarkus:quarkus-update-recipes reference-only suppression.
+            Added: 2026-07-13
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.camel\.upgrade/camel-upgrade-recipes@.*$</packageUrl>
+        <cpe>cpe:/a:apache:camel</cpe>
     </suppress>
 </suppressions>


### PR DESCRIPTION
- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1125

Two CPE over-match false positives from the 2026-07-13 OpenRewrite vulnerability report, both suppressed indefinitely in the shared suppressions file (they can never become true positives for the matched artifacts).

### 1. `CVE-2026-54428` — httpcore/httpcore-nio 4.4.x (HIGH)
CVE-2026-54428 is an **HTTP/2 HPACK-decoder** memory-exhaustion DoS in Apache HttpComponents **Core 5.x** (`org.apache.httpcomponents.core5:httpcore5`, ≤ 5.4.2 / 5.5-beta1). HTTP/2 does not exist in the separate 4.x line (`org.apache.httpcomponents:httpcore` / `httpcore-nio` 4.4.13, 4.4.16), but the NVD CPE range `apache:httpcomponents_core ≤ 5.4.2` numerically over-matches those 4.x jars. Same-vendor cross-product-line over-match — identical to the existing `CVE-2026-54399` block, so it sits next to it. Affected repos: `rewrite-ai-search`, `rewrite-third-party`.

### 2. `camel-upgrade-recipes` — apache:camel CPE (CRITICAL, 32 CVEs)
`org.apache.camel.upgrade:camel-upgrade-recipes` is the OpenRewrite recipe artifact that migrates user code between Camel versions — recipe definitions, **not** the Camel runtime. Its version tracks Camel releases (4.20.0), so the `apache:camel` CPE numerically over-matches it and floods the scan with Camel runtime CVEs (camel-core, camel-pqc, …) that this artifact does not ship. Suppressed reference-only via `<packageUrl>` + `<cpe>cpe:/a:apache:camel</cpe>`, mirroring the existing `io.quarkus:quarkus-update-recipes` suppression. Affected repos: `rewrite-third-party`, `rewrite-recipe-bom`.

### Also
- Flipped the existing `CVE-2026-54399` httpcore-4.x block from `until="2026-08-01Z"` to indefinite, per current guidance for permanent same-vendor CPE over-matches.

`xmllint --noout` passes. A patch release of the plugin is required for downstream repos to pick this up.